### PR TITLE
Refactor JNI interface

### DIFF
--- a/crossterm/cargo/src/api.rs
+++ b/crossterm/cargo/src/api.rs
@@ -1,19 +1,19 @@
 use std::convert::TryInto;
-use std::io::Write;
+use std::io::{stdout, Write};
 use std::time::Duration;
 
-use crossterm::{cursor, event, queue, style, terminal};
+use crossterm::{cursor, event, terminal};
 use jni::{
     JNIEnv,
-    objects::{JClass, JObject, JString},
-    sys::{jboolean, jint, jobject},
+    objects::{JClass, JObject},
+    sys::{jboolean, jobject},
 };
 
 use crate::{
     jni_from_jvm,
     jni_to_jvm,
     jvm_unwrapper::JvmUnwrapper,
-    unify_errors::UnifyErrors
+    unify_errors::UnifyErrors,
 };
 
 #[no_mangle]
@@ -79,269 +79,24 @@ pub extern "system" fn Java_tui_crossterm_CrosstermJni_read(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalClear(
+pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueue(
     env: JNIEnv,
     _class: JClass,
-    clear_type_enum_value: JObject,
+    commands_list_object: JObject,
 ) {
-    jni_from_jvm::clear_type(env, clear_type_enum_value)
-        .unify_errors()
-        .and_then(|clear_type| queue!(std::io::stdout(), terminal::Clear(clear_type)).unify_errors())
-        .jvm_unwrap(env);
+    let mut stdout1 = stdout();
+    let writer = stdout1.by_ref();
+    jni_from_jvm::queue_commands(writer, env, commands_list_object).jvm_unwrap(env);
 }
 
 #[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventPushKeyboardEnhancementFlags(
+pub extern "system" fn Java_tui_crossterm_CrosstermJni_execute(
     env: JNIEnv,
     _class: JClass,
-    keyboard_enchancement_obj: JObject,
+    commands_list_object: JObject,
 ) {
-    jni_from_jvm::keyboard_enhancement_flags(env, keyboard_enchancement_obj)
-        .unify_errors()
-        .and_then(|flags| queue!(std::io::stdout(),event::PushKeyboardEnhancementFlags(flags)).unify_errors())
-        .jvm_unwrap(env)
+    let mut stdout1 = stdout();
+    let writer = stdout1.by_ref();
+    jni_from_jvm::queue_commands(writer, env, commands_list_object).jvm_unwrap(env);
+    writer.flush().jvm_unwrap(env);
 }
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorSetCursorShape(
-    env: JNIEnv,
-    _class: JClass,
-    cursor_shape_enum: JObject,
-) {
-    jni_from_jvm::cursor_shape(env, cursor_shape_enum)
-        .unify_errors()
-        .and_then(|cursor_shape| queue!(std::io::stdout(), cursor::SetCursorShape(cursor_shape)).unify_errors())
-        .jvm_unwrap(env);
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetAttribute(
-    env: JNIEnv,
-    _class: JClass,
-    attribute_enum_value: JObject,
-) {
-    jni_from_jvm::attribute(env, attribute_enum_value)
-        .unify_errors()
-        .and_then(|attribute| queue!(std::io::stdout(), style::SetAttribute(attribute)).unify_errors())
-        .jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetAttributes(
-    env: JNIEnv,
-    _class: JClass,
-    attributes_obj: JObject,
-) {
-    let attributes: style::Attributes = jni_from_jvm::attributes(env, attributes_obj).jvm_unwrap(env);
-    queue!(std::io::stdout(), style::SetAttributes(attributes)).jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetBackgroundColor(
-    env: JNIEnv,
-    _class: JClass,
-    color_record_object: JObject,
-) {
-    jni_from_jvm::color(env, color_record_object)
-        .unify_errors()
-        .and_then(|color| queue!(std::io::stdout(), style::SetBackgroundColor(color)).unify_errors())
-        .jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetColors(
-    env: JNIEnv,
-    _class: JClass,
-    foreground: JObject,
-    background: JObject,
-) {
-    let foreground = jni_from_jvm::optional_color(env, foreground).jvm_unwrap(env);
-    let background = jni_from_jvm::optional_color(env, background).jvm_unwrap(env);
-
-    let colors = style::Colors {
-        foreground,
-        background,
-    };
-    queue!(std::io::stdout(), style::SetColors(colors)).jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetForegroundColor(
-    env: JNIEnv,
-    _class: JClass,
-    color_record_object: JObject,
-) {
-    jni_from_jvm::color(env, color_record_object)
-        .unify_errors()
-        .and_then(|color| queue!(std::io::stdout(), style::SetForegroundColor(color)).unify_errors())
-        .jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetStyle(
-    env: JNIEnv,
-    _class: JClass,
-    // The foreground color. Optional<Color>
-    foreground_color: JObject,
-    // The background color. Optional<Color>
-    background_color: JObject,
-    // The underline color. Optional<Color>
-    underline_color: JObject,
-    // List of attributes. Attributes
-    attributes: JObject,
-) {
-    let content_style = style::ContentStyle {
-        foreground_color: jni_from_jvm::optional_color(env, foreground_color).jvm_unwrap(env),
-        background_color: jni_from_jvm::optional_color(env, background_color).jvm_unwrap(env),
-        underline_color: jni_from_jvm::optional_color(env, underline_color).jvm_unwrap(env),
-        attributes: jni_from_jvm::attributes(env, attributes).jvm_unwrap(env),
-    };
-    queue!(std::io::stdout(), style::SetStyle(content_style)).jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleSetUnderlineColor(
-    env: JNIEnv,
-    _class: JClass,
-    color_record_object: JObject,
-) {
-    jni_from_jvm::color(env, color_record_object)
-        .unify_errors()
-        .and_then(|color| queue!(std::io::stdout(), style::SetUnderlineColor(color)).unify_errors())
-        .jvm_unwrap(env)
-}
-
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStylePrint(
-    env: JNIEnv,
-    _class: JClass,
-    value: JString,
-) {
-    let input: String = env
-        .get_string(value)
-        .expect("enqueue_style_print: Couldn't get java string!")
-        .into();
-
-    queue!(std::io::stdout(), style::Print(input)).jvm_unwrap(env)
-}
-
-// events
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorDisableBlinking(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::DisableBlinking).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorEnableBlinking(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::EnableBlinking).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorHide(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::Hide).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveDown(env: JNIEnv, _class: JClass, num_rows: jint) { queue!(std::io::stdout(), cursor::MoveDown(num_rows as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveLeft(env: JNIEnv, _class: JClass, num_cols: jint) { queue!(std::io::stdout(), cursor::MoveLeft(num_cols as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveRight(env: JNIEnv, _class: JClass, num_cols: jint) { queue!(std::io::stdout(), cursor::MoveRight(num_cols as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveTo(env: JNIEnv, _class: JClass, x: jint, y: jint) { queue!(std::io::stdout(), cursor::MoveTo(x as u16, y as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveToColumn(env: JNIEnv, _class: JClass, col: jint) { queue!(std::io::stdout(), cursor::MoveToColumn(col as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveToNextLine(env: JNIEnv, _class: JClass, num_lines: jint) { queue!(std::io::stdout(), cursor::MoveToNextLine(num_lines as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveToPreviousLine(env: JNIEnv, _class: JClass, num_lines: jint) { queue!(std::io::stdout(), cursor::MoveToPreviousLine(num_lines as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveToRow(env: JNIEnv, _class: JClass, row: jint) { queue!(std::io::stdout(), cursor::MoveToRow(row as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorMoveUp(env: JNIEnv, _class: JClass, num_rows: jint) { queue!(std::io::stdout(), cursor::MoveUp(num_rows as u16)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorRestorePosition(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::RestorePosition).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorSavePosition(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::SavePosition).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueCursorShow(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), cursor::Show).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventDisableBracketedPaste(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::DisableBracketedPaste).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventDisableFocusChange(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::DisableFocusChange).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventDisableMouseCapture(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::DisableMouseCapture).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventEnableBracketedPaste(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::EnableBracketedPaste).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventEnableFocusChange(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::EnableFocusChange).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventEnableMouseCapture(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::EnableMouseCapture).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueEventPopKeyboardEnhancementFlags(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), event::PopKeyboardEnhancementFlags).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueStyleResetColor(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), style::ResetColor).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalDisableLineWrap(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), terminal::DisableLineWrap).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalEnableLineWrap(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), terminal::EnableLineWrap).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalEnterAlternateScreen(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), terminal::EnterAlternateScreen).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalLeaveAlternateScreen(env: JNIEnv, _class: JClass) { queue!(std::io::stdout(), terminal::LeaveAlternateScreen).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalScrollDown(env: JNIEnv, _class: JClass, value: u16) { queue!(std::io::stdout(), terminal::ScrollDown(value)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalScrollUp(env: JNIEnv, _class: JClass, value: u16) { queue!(std::io::stdout(), terminal::ScrollUp(value)).jvm_unwrap(env) }
-
-#[rustfmt::skip]
-#[no_mangle]
-pub extern "system" fn Java_tui_crossterm_CrosstermJni_enqueueTerminalSetSize(env: JNIEnv, _class: JClass, x: u16, y: u16) { queue!(std::io::stdout(), terminal::SetSize(x, y)).jvm_unwrap(env) }

--- a/crossterm/cargo/src/jni_from_jvm.rs
+++ b/crossterm/cargo/src/jni_from_jvm.rs
@@ -1,27 +1,54 @@
-use jni::{
-    errors::{Result as JniResult},
-    objects::{JObject, JString},
-    strings::{JNIString, JavaStr},
-    JNIEnv,
-};
-use std::ops::BitOr;
 use std::convert::TryInto;
+use std::io::Write;
+use std::ops::BitOr;
 
-use crossterm::{cursor, event, style, terminal};
+use crossterm::{cursor, event, QueueableCommand, style, terminal};
+use jni::{
+    errors::Result as JniResult,
+    JNIEnv,
+    objects::{JObject, JString},
+    strings::{JavaStr, JNIString},
+    sys::jint,
+};
+
+use crate::unify_errors::{UnifiedError, UnifiedResult, UnifyErrors};
 
 fn get_name<'a>(env: JNIEnv<'a>, enum_value: JObject<'a>) -> JniResult<JString<'a>> {
     let object = env
         .call_method(enum_value, "name", "()Ljava/lang/String;", &[])?
         .l()?;
 
-    return Ok(object.into());
+    Ok(object.into())
 }
 
-fn int_field<F>(env: JNIEnv, obj: JObject, name: F) -> JniResult<u8>
-    where
-        F: Into<JNIString>,
-{
-    return Ok(env.get_field(obj, name, "I")?.i()?.try_into().unwrap());
+fn int_field<F>(env: JNIEnv, obj: JObject, name: F) -> JniResult<jint> where F: Into<JNIString> {
+    Ok(env.get_field(obj, name, "I")?.i()?)
+}
+
+// one doesn't simply...
+fn as_rust_string(env: JNIEnv, _1: JObject) -> JniResult<String> {
+    let _2: JString = _1.into();
+    let _3: JavaStr = env.get_string(_2)?;
+    let _4: String = _3.to_string_lossy().into();
+    Ok(_4)
+}
+
+fn str_field<F>(env: JNIEnv, obj: JObject, name: F) -> JniResult<String> where F: Into<JNIString> {
+    let object: JObject = env.get_field(obj, name, "Ljava/lang/String;")?.l()?;
+    as_rust_string(env, object)
+}
+
+fn u16_field<F>(env: JNIEnv, obj: JObject, name: F) -> UnifiedResult<u16> where F: Into<JNIString> {
+    let i = int_field(env, obj, name).unify_errors()?;
+    <i32 as TryInto<u16>>::try_into(i).map_err(|_| UnifiedError::NotU16(i))
+}
+
+fn object_field<'a, F, T>(env: JNIEnv<'a>, obj: JObject<'a>, name: F, ty: T) -> JniResult<JObject<'a>> where F: Into<JNIString>, T: Into<JNIString> + AsRef<str> {
+    Ok(env.get_field(obj, name, ty)?.l()?)
+}
+
+pub fn to_string(env: JNIEnv, obj: JObject) -> JniResult<String> {
+    as_rust_string(env, env.call_method(obj, "toString", "()Ljava/lang/String;", &[])?.l()?)
 }
 
 pub fn clear_type(env: JNIEnv, enum_value: JObject) -> JniResult<terminal::ClearType> {
@@ -39,7 +66,7 @@ pub fn clear_type(env: JNIEnv, enum_value: JObject) -> JniResult<terminal::Clear
         }
     }
 
-    return Ok(from_str(&javastr.to_string_lossy()));
+    Ok(from_str(&javastr.to_string_lossy()))
 }
 
 pub fn optional_color(env: JNIEnv, optional_object: JObject) -> JniResult<Option<style::Color>> {
@@ -58,13 +85,7 @@ pub fn optional_color(env: JNIEnv, optional_object: JObject) -> JniResult<Option
 }
 
 pub fn color(env: JNIEnv, record_object: JObject) -> JniResult<style::Color> {
-    // let's save ourselves typing out all those is_instance_of checks
-    let stringified_obj = env
-        .call_method(record_object, "toString", "()Ljava/lang/String;", &[])?
-        .l()?;
-
-    let stringified_javastr: JavaStr = env.get_string(stringified_obj.into())?;
-    let str = stringified_javastr.to_string_lossy();
+    let str = to_string(env, record_object)?;
     // Blue[]
     // Rgb[r=1, g=2, b=3]
     let x: Vec<&str> = str.split("[").collect();
@@ -88,11 +109,11 @@ pub fn color(env: JNIEnv, record_object: JObject) -> JniResult<style::Color> {
         "White" => style::Color::White,
         "Grey" => style::Color::Grey,
         "Rgb" => style::Color::Rgb {
-            r: int_field(env, record_object, "r")?,
-            g: int_field(env, record_object, "g")?,
-            b: int_field(env, record_object, "b")?,
+            r: int_field(env, record_object, "r")?.try_into().unwrap(),
+            g: int_field(env, record_object, "g")?.try_into().unwrap(),
+            b: int_field(env, record_object, "b")?.try_into().unwrap(),
         },
-        "AnsiValue" => style::Color::AnsiValue(int_field(env, record_object, "color")?),
+        "AnsiValue" => style::Color::AnsiValue(int_field(env, record_object, "color")?.try_into().unwrap()),
         other => {
             panic!("unknown color: {}", other);
         }
@@ -147,6 +168,10 @@ pub fn attributes(env: JNIEnv, attributes_obj: JObject) -> JniResult<style::Attr
         .call_method(attributes_obj, "attributes", "()Ljava/util/List;", &[])?
         .l()?;
 
+    return attributes_list(env, attributes_list_obj);
+}
+
+pub fn attributes_list(env: JNIEnv, attributes_list_obj: JObject) -> JniResult<style::Attributes> {
     let list = env.get_list(attributes_list_obj)?;
 
     let attributes: style::Attributes = list
@@ -176,5 +201,182 @@ pub fn keyboard_enhancement_flags(
     obj: JObject,
 ) -> JniResult<event::KeyboardEnhancementFlags> {
     let bits = int_field(env, obj, "bits")?;
-    return Ok(event::KeyboardEnhancementFlags::from_bits_truncate(bits));
+    return Ok(event::KeyboardEnhancementFlags::from_bits_truncate(bits.try_into().unwrap()));
+}
+
+pub fn queue_commands<W: Write>(w: &mut W, env: JNIEnv, list_obj: JObject) -> UnifiedResult<()> {
+    let list = env.get_list(list_obj).unify_errors()?;
+    for obj in list.iter().unify_errors()? {
+        queue_command(w, env, obj)?
+    }
+    return Ok(());
+}
+
+/// it's clearly weird for this to queue directly.
+/// That is because it seems to be impossible to return `impl Command` from a function, because
+/// it is apparently not "object safe" so dynamic dispatch cannot be used.
+pub fn queue_command<W: Write>(w: &mut W, env: JNIEnv, obj: JObject) -> UnifiedResult<()> {
+    let str = to_string(env, obj).unify_errors()?;
+    // eprintln!("{str:?}");
+    let parts: Vec<&str> = str.split("[").collect();
+    let class_name = parts[0];
+
+    match class_name {
+        "MoveTo" => {
+            let x = u16_field(env, obj, "x")?;
+            let y = u16_field(env, obj, "y")?;
+            w.queue(cursor::MoveTo(x, y)).unify_errors()?
+        }
+        "MoveToNextLine" => {
+            let num_lines = u16_field(env, obj, "num_lines")?;
+            w.queue(cursor::MoveToNextLine(num_lines)).unify_errors()?
+        }
+        "MoveToPreviousLine" => {
+            let num_lines = u16_field(env, obj, "num_lines")?;
+            w.queue(cursor::MoveToPreviousLine(num_lines)).unify_errors()?
+        }
+        "MoveToColumn" => {
+            let num_lines = u16_field(env, obj, "num_lines")?;
+            w.queue(cursor::MoveToColumn(num_lines)).unify_errors()?
+        }
+        "MoveToRow" => {
+            let row = u16_field(env, obj, "row")?;
+            w.queue(cursor::MoveToRow(row)).unify_errors()?
+        }
+        "MoveUp" => {
+            let num_rows = u16_field(env, obj, "num_rows")?;
+            w.queue(cursor::MoveUp(num_rows)).unify_errors()?
+        }
+        "MoveRight" => {
+            let num_columns = u16_field(env, obj, "num_columns")?;
+            w.queue(cursor::MoveRight(num_columns)).unify_errors()?
+        }
+        "MoveDown" => {
+            let num_rows = u16_field(env, obj, "num_rows")?;
+            w.queue(cursor::MoveDown(num_rows)).unify_errors()?
+        }
+        "MoveLeft" => {
+            let num_columns = u16_field(env, obj, "num_columns")?;
+            w.queue(cursor::MoveLeft(num_columns)).unify_errors()?
+        }
+        "SavePosition" => {
+            w.queue(cursor::SavePosition).unify_errors()?
+        }
+        "RestorePosition" => {
+            w.queue(cursor::RestorePosition).unify_errors()?
+        }
+        "Hide" => {
+            w.queue(cursor::Hide).unify_errors()?
+        }
+        "Show" => {
+            w.queue(cursor::Show).unify_errors()?
+        }
+        "EnableBlinking" => {
+            w.queue(cursor::EnableBlinking).unify_errors()?
+        }
+        "DisableBlinking" => {
+            w.queue(cursor::DisableBlinking).unify_errors()?
+        }
+        "SetCursorShape" => {
+            let x = cursor_shape(env, object_field(env, obj, "cursor_shape", "Ltui/crossterm/CursorShape;").unify_errors()?).unify_errors()?;
+            w.queue(cursor::SetCursorShape(x)).unify_errors()?
+        }
+        "EnableMouseCapture" => {
+            w.queue(event::EnableMouseCapture).unify_errors()?
+        }
+        "DisableMouseCapture" => {
+            w.queue(event::DisableMouseCapture).unify_errors()?
+        }
+        "PushKeyboardEnhancementFlags" => {
+            let x = keyboard_enhancement_flags(env, object_field(env, obj, "flags", "Ltui/crossterm/KeyboardEnhancementFlags;").unify_errors()?).unify_errors()?;
+            w.queue(event::PushKeyboardEnhancementFlags(x)).unify_errors()?
+        }
+        "PopKeyboardEnhancementFlags" => {
+            w.queue(event::PopKeyboardEnhancementFlags).unify_errors()?
+        }
+        "EnableFocusChange" => {
+            w.queue(event::EnableFocusChange).unify_errors()?
+        }
+        "DisableFocusChange" => {
+            w.queue(event::DisableFocusChange).unify_errors()?
+        }
+        "EnableBracketedPaste" => {
+            w.queue(event::EnableBracketedPaste).unify_errors()?
+        }
+        "DisableBracketedPaste" => {
+            w.queue(event::DisableBracketedPaste).unify_errors()?
+        }
+        "SetForegroundColor" => {
+            let x = color(env, object_field(env, obj, "color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            w.queue(style::SetForegroundColor(x)).unify_errors()?
+        }
+        "SetBackgroundColor" => {
+            let x = color(env, object_field(env, obj, "color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            w.queue(style::SetBackgroundColor(x)).unify_errors()?
+        }
+        "SetUnderlineColor" => {
+            let x = color(env, object_field(env, obj, "color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            w.queue(style::SetUnderlineColor(x)).unify_errors()?
+        }
+        "SetColors" => {
+            let foreground = optional_color(env, object_field(env, obj, "foreground", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            let background = optional_color(env, object_field(env, obj, "background", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            let set_colors = style::SetColors(style::Colors { foreground, background });
+            w.queue(set_colors).unify_errors()?
+        }
+        "SetAttribute" => {
+            let x = attribute(env, object_field(env, obj, "attribute", "Ltui/crossterm/Attribute;").unify_errors()?).unify_errors()?;
+            w.queue(style::SetAttribute(x)).unify_errors()?
+        }
+        "SetAttributes" => {
+            let x = attributes_list(env, object_field(env, obj, "attributes", "Ljava/util/List;").unify_errors()?).unify_errors()?;
+            w.queue(style::SetAttributes(x)).unify_errors()?
+        }
+        "SetStyle" => {
+            let foreground_color = optional_color(env, object_field(env, obj, "foreground_color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            let background_color = optional_color(env, object_field(env, obj, "background_color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            let underline_color = optional_color(env, object_field(env, obj, "underline_color", "Ltui/crossterm/Color;").unify_errors()?).unify_errors()?;
+            let attributes = attributes_list(env, object_field(env, obj, "attributes", "Ljava/util/List;").unify_errors()?).unify_errors()?;
+            let content_style = style::ContentStyle { foreground_color, background_color, underline_color, attributes };
+            w.queue(style::SetStyle(content_style)).unify_errors()?
+        }
+        "ResetColor" => {
+            w.queue(style::ResetColor).unify_errors()?
+        }
+        "DisableLineWrap" => {
+            w.queue(terminal::DisableLineWrap).unify_errors()?
+        }
+        "EnableLineWrap" => {
+            w.queue(terminal::EnableLineWrap).unify_errors()?
+        }
+        "EnterAlternateScreen" => {
+            w.queue(terminal::EnterAlternateScreen).unify_errors()?
+        }
+        "LeaveAlternateScreen" => {
+            w.queue(terminal::LeaveAlternateScreen).unify_errors()?
+        }
+        "ScrollUp" => {
+            let num_rows = u16_field(env, obj, "num_rows")?;
+            w.queue(terminal::ScrollUp(num_rows)).unify_errors()?
+        }
+        "ScrollDown" => {
+            let num_rows = u16_field(env, obj, "num_rows")?;
+            w.queue(terminal::ScrollDown(num_rows)).unify_errors()?
+        }
+        "Clear" => {
+            let x = clear_type(env, object_field(env, obj, "clear_type", "Ltui/crossterm/ClearType;").unify_errors()?).unify_errors()?;
+            w.queue(terminal::Clear(x)).unify_errors()?
+        }
+        "SetSize" => {
+            let columns = u16_field(env, obj, "columns")?;
+            let rows = u16_field(env, obj, "rows")?;
+            w.queue(terminal::SetSize(columns, rows)).unify_errors()?
+        }
+        "Print" => {
+            let value = str_field(env, obj, "value").unify_errors()?;
+            w.queue(style::Print(value)).unify_errors()?
+        }
+        other => panic!("Not a valid Command: {}", other),
+    };
+    Ok(())
 }

--- a/crossterm/cargo/src/jni_from_jvm.rs
+++ b/crossterm/cargo/src/jni_from_jvm.rs
@@ -163,14 +163,6 @@ pub fn attribute(env: JNIEnv, attribute_enum_value: JObject) -> JniResult<style:
     return Ok(from_str(&java_str.to_string_lossy()));
 }
 
-pub fn attributes(env: JNIEnv, attributes_obj: JObject) -> JniResult<style::Attributes> {
-    let attributes_list_obj = env
-        .call_method(attributes_obj, "attributes", "()Ljava/util/List;", &[])?
-        .l()?;
-
-    return attributes_list(env, attributes_list_obj);
-}
-
 pub fn attributes_list(env: JNIEnv, attributes_list_obj: JObject) -> JniResult<style::Attributes> {
     let list = env.get_list(attributes_list_obj)?;
 

--- a/crossterm/cargo/src/unify_errors.rs
+++ b/crossterm/cargo/src/unify_errors.rs
@@ -1,10 +1,14 @@
 use std::io;
 use jni::errors::{Error as JniError};
+use jni::sys::jint;
 
 pub enum UnifiedError {
     Jni(JniError),
     Io(io::Error),
+    NotU16(jint),
 }
+
+pub type UnifiedResult<T> = Result<T, UnifiedError>;
 
 pub trait UnifyErrors<T> {
     fn unify_errors(self) -> Result<T, UnifiedError>;

--- a/crossterm/src/java/tui/crossterm/Command.java
+++ b/crossterm/src/java/tui/crossterm/Command.java
@@ -43,7 +43,8 @@ public sealed interface Command
         Command.ScrollUp,
         Command.ScrollDown,
         Command.Clear,
-        Command.SetSize {
+        Command.SetSize,
+        Command.Print {
     /// A command that moves the terminal cursor to the given position (column, row).
     /// * Top left cell is represented as `0,0`.
     record MoveTo(int x, int y) implements Command {
@@ -263,5 +264,8 @@ public sealed interface Command
 
     /// A command that sets the terminal buffer size `(columns, rows)`.
     record SetSize(int columns, int rows) implements Command {
+    }
+
+    record Print(String value) implements Command {
     }
 }

--- a/crossterm/src/java/tui/crossterm/CrosstermJni.java
+++ b/crossterm/src/java/tui/crossterm/CrosstermJni.java
@@ -1,6 +1,7 @@
 package tui.crossterm;
 
-import java.util.Optional;
+import java.util.Arrays;
+import java.util.List;
 
 public class CrosstermJni {
     static {
@@ -24,92 +25,15 @@ public class CrosstermJni {
 
     public native void enableRawMode();
 
-    public native void enqueueCursorDisableBlinking();
+    public native void enqueue(List<Command> commands);
 
-    public native void enqueueCursorEnableBlinking();
+    final public void enqueue(Command ...commands) {
+        enqueue(java.util.Arrays.asList(commands));
+    }
 
-    public native void enqueueCursorHide();
+    public native void execute(List<Command> commands);
 
-    public native void enqueueCursorMoveDown(int num_rows);
-
-    public native void enqueueCursorMoveLeft(int num_cols);
-
-    public native void enqueueCursorMoveRight(int num_cols);
-
-    public native void enqueueCursorMoveTo(int x, int y);
-
-    public native void enqueueCursorMoveToColumn(int col);
-
-    public native void enqueueCursorMoveToNextLine(int num_lines);
-
-    public native void enqueueCursorMoveToPreviousLine(int num_lines);
-
-    public native void enqueueCursorMoveToRow(int row);
-
-    public native void enqueueCursorMoveUp(int num_rows);
-
-    public native void enqueueCursorRestorePosition();
-
-    public native void enqueueCursorSavePosition();
-
-    public native void enqueueCursorShow();
-
-    public native void enqueueEventDisableBracketedPaste();
-
-    public native void enqueueEventDisableFocusChange();
-
-    public native void enqueueEventDisableMouseCapture();
-
-    public native void enqueueEventEnableBracketedPaste();
-
-    public native void enqueueEventEnableFocusChange();
-
-    public native void enqueueEventEnableMouseCapture();
-
-    public native void enqueueEventPopKeyboardEnhancementFlags();
-
-    public native void enqueueStyleResetColor();
-
-    public native void enqueueTerminalDisableLineWrap();
-
-    public native void enqueueTerminalEnableLineWrap();
-
-    public native void enqueueTerminalEnterAlternateScreen();
-
-    public native void enqueueTerminalLeaveAlternateScreen();
-
-    public native void enqueueTerminalScrollDown(int value);
-
-    public native void enqueueTerminalScrollUp(int value);
-
-    public native void enqueueTerminalSetSize(int x, int y);
-
-    public native void enqueueTerminalClear(ClearType value);
-
-    public native void enqueueEventPushKeyboardEnhancementFlags(KeyboardEnhancementFlags value);
-
-    public native void enqueueCursorSetCursorShape(CursorShape value);
-
-    public native void enqueueStyleSetAttribute(Attribute attribute);
-
-    public native void enqueueStyleSetAttributes(Attributes attributes);
-
-    public native void enqueueStyleSetBackgroundColor(Color color);
-
-    public native void enqueueStyleSetColors(Optional<Color> foreground, Optional<Color> background);
-
-    public native void enqueueStyleSetForegroundColor(Color color);
-
-    public native void enqueueStyleSetStyle(
-            /// The foreground color.
-            Optional<Color> foreground_color,
-            /// The background color.
-            Optional<Color> background_color,
-            /// The underline color.
-            Optional<Color> underline_color,
-            /// List of attributes.
-            Attributes attributes
-    );
-
-    public native void enqueueStylePrint(String value);
+    final public void execute(Command ...commands) {
+        execute(Arrays.asList(commands));
+    }
 }


### PR DESCRIPTION
- replace all `enqueue*` methods with `enqueue` and `execute` which takes a list of commands, making us cross the native barrier far fewer times
- make sure we don't panic when ints do not fit in u16 (which is mostly used by crossterm) (see #10)
- make backends `hide_cursor` with friends `execute` instead of `enqueue` (they were that way originally)