### PR TITLE
Apple m1 continue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,6 @@ jobs:
           key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
 
-      - name: Install bleep stable
-        run: cs install --channel https://raw.githubusercontent.com/oyvindberg/bleep/master/coursier-channel.json bleep --verbose
-
       - name: Build jni library
         run: bleep gen-jni-library
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
-      - uses: coursier/setup-action@v1.2.0-M3
+      - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
           extraFiles: bleep.yaml
-
-      - name: Install bleep stable
-        run: cs install --channel https://raw.githubusercontent.com/oyvindberg/bleep/master/coursier-channel.json bleep --verbose
 
       - name: Scalafmt Check
         run: bleep fmt --check
@@ -48,22 +45,22 @@ jobs:
             jni-folder: .bleep\generated-resources\crossterm\native
     steps:
       - uses: actions/checkout@v2
-      - uses: coursier/setup-action@v1.2.0-M3
+      - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
           extraFiles: bleep.yaml
-#      - name: Set up cargo cache
-#        uses: actions/cache@v3
-#        continue-on-error: false
-#        with:
-#          path: |
-#            ~/.cargo/bin/
-#            ~/.cargo/registry/index/
-#            ~/.cargo/registry/cache/
-#            ~/.cargo/git/db/
-#            target/
-#          key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-#          restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
 
       - name: Install bleep stable
         run: cs install --channel https://raw.githubusercontent.com/oyvindberg/bleep/master/coursier-channel.json bleep --verbose
@@ -108,9 +105,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - uses: actions/checkout@v2
-      - uses: coursier/setup-action@v1.2.0-M3
-      - name: Install bleep stable
-        run: cs install --channel https://raw.githubusercontent.com/oyvindberg/bleep/master/coursier-channel.json bleep --verbose
+      - uses: bleep-build/bleep-setup-action@0.0.1
       - id: get_version
         uses: battila7/get-version-action@v2
       - name: Download artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,18 +52,18 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraFiles: bleep.yaml
-      - name: Set up cargo cache
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
+#      - name: Set up cargo cache
+#        uses: actions/cache@v3
+#        continue-on-error: false
+#        with:
+#          path: |
+#            ~/.cargo/bin/
+#            ~/.cargo/registry/index/
+#            ~/.cargo/registry/cache/
+#            ~/.cargo/git/db/
+#            target/
+#          key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+#          restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
 
       - name: Install bleep stable
         run: cs install --channel https://raw.githubusercontent.com/oyvindberg/bleep/master/coursier-channel.json bleep --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,8 @@ jobs:
         # as is normal, everything involving windows is terrible.
         # - powershell doesn't work, for one: https://github.com/dirs-dev/directories-jvm/issues/49
         # - with `shell: cmd` only one command can be run at a time, so this is split up
-      - name: bleep compile-server auto-shutdown-enable (windows)
-        run: bleep compile-server auto-shutdown-enable
+      - name: bleep config compile-server auto-shutdown-enable (windows)
+        run: bleep config compile-server auto-shutdown-enable
         shell: cmd
         if: runner.os == 'Windows'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: v1-${{ runner.arch }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.arch }}-${{ runner.os }}-cargo-
 
       - name: Build jni library

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -1,5 +1,5 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
-$version: 0.0.1-M23
+$version: 0.0.1-M24
 jvm:
   name: zulu:17.0.1
 projects:

--- a/scripts/src/scala/tui/scripts/GenJniLibrary.scala
+++ b/scripts/src/scala/tui/scripts/GenJniLibrary.scala
@@ -14,11 +14,13 @@ object GenJniLibrary extends BleepScript("GenJniLibrary") {
       libName = "crossterm",
       env = sys.env.toList
     ) {
-      // fix broken platform detection
       override lazy val nativePlatform: String =
         OsArch.current match {
+          case OsArch.LinuxAmd64    => "x86_64-linux"
+          case OsArch.WindowsAmd64  => "x86_64-msys_nt-10.0-20348"
+          case OsArch.MacosAmd64    => "x86_64-darwin"
           case OsArch.MacosArm64(_) => "arm64-darwin"
-          case _                    => super.nativePlatform
+          case other: OsArch.Other  => sys.error(s"not implemented: $other")
         }
     }
 

--- a/scripts/src/scala/tui/scripts/GenJniLibrary.scala
+++ b/scripts/src/scala/tui/scripts/GenJniLibrary.scala
@@ -13,10 +13,16 @@ object GenJniLibrary extends BleepScript("GenJniLibrary") {
       nativeBuildTool = new Cargo(release = true),
       libName = "crossterm",
       env = sys.env.toList
-    )
+    ) {
+      // fix broken platform detection
+      override lazy val nativePlatform: String =
+        OsArch.current match {
+          case OsArch.MacosArm64(_) => "arm64-darwin"
+          case _                    => super.nativePlatform
+        }
+    }
 
   override def run(started: Started, commands: Commands, args: List[String]): Unit = {
-
     val jniNative = crosstermJniNativeLib(started)
     val jniPackage = new JniPackage(started.buildPaths.buildDir, jniNative)
 

--- a/scripts/src/scala/tui/scripts/GenNativeImage.scala
+++ b/scripts/src/scala/tui/scripts/GenNativeImage.scala
@@ -46,7 +46,7 @@ object GenNativeImage extends BleepScript("GenNativeImage") {
         case Some(relPath) =>
           // smoothen over some irritation from github action scripts
           val relPathNoExe = if (relPath.endsWith(".exe")) relPath.dropRight(".exe".length) else relPath
-          started.prebootstrapped.buildPaths.cwd / relPathNoExe
+          started.pre.buildPaths.cwd / relPathNoExe
         case None => super.nativeImageOutput
       }
     }


### PR DESCRIPTION
- bump to bleep 0.0.1-M24
- use `bleep-build/bleep-setup-action@0.0.1`
- fix broken platform detection code in jni plugin (`uname -sm` somehow picks up `x86_64` from an arm process. I'm baffled)