### PR TITLE
chore(ci): bump checkout action and add in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
@@ -44,7 +44,7 @@ jobs:
           - os: windows-latest
             jni-folder: .bleep\generated-resources\crossterm\native
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
@@ -101,7 +101,7 @@ jobs:
     needs: [ build, build-native ]
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: bleep-build/bleep-setup-action@0.0.1
       - id: get_version
         uses: battila7/get-version-action@v2


### PR DESCRIPTION
This will get rid of the node 12 warnings in the runs. I also just added
dependabot to ensure the action versions are kept up-to-date
automatically.
