### PR TITLE
chore: migrate all code docs to valid scaladoc

### DIFF
--- a/tui/src/scala/tui/Borders.scala
+++ b/tui/src/scala/tui/Borders.scala
@@ -1,6 +1,7 @@
 package tui
 
-/// Bitflags that can be composed to set the visible borders essentially on the block widget.
+/** Bitflags that can be composed to set the visible borders essentially on the block widget.
+  */
 case class Borders(bits: Int) {
   def fmt(sb: StringBuilder): Unit = {
     var first = true
@@ -51,18 +52,21 @@ case class Borders(bits: Int) {
     sb.toString()
   }
 
-  /// Returns `true` if all of the flags in `other` are contained within `self`.
+  /** Returns `true` if all of the flags in `other` are contained within `self`.
+    */
   def contains(other: Borders): Boolean =
     other != Borders.EMPTY && (bits & other.bits) == other.bits
 
   def intersects(other: Borders): Boolean =
     Borders.EMPTY.bits != (bits & other.bits)
 
-  /// Inserts the specified flags in-place.
+  /** Inserts the specified flags in-place.
+    */
   def insert(other: Borders): Borders =
     copy(bits = bits | other.bits)
 
-  /// Removes the specified flags in-place.
+  /** Removes the specified flags in-place.
+    */
   def remove(other: Borders): Borders =
     copy(bits = bits & Integer.reverse(other.bits))
 
@@ -74,18 +78,32 @@ case class Borders(bits: Int) {
 }
 
 object Borders {
-  /// Show no border (default)
+
+  /** Show no border (default)
+    */
   val NONE: Borders = Borders(1 << 0)
-  /// Show the top border
+
+  /** Show the top border
+    */
   val TOP: Borders = Borders(1 << 1)
-  /// Show the right border
+
+  /** Show the right border
+    */
   val RIGHT: Borders = Borders(1 << 2)
-  /// Show the bottom border
+
+  /** Show the bottom border
+    */
   val BOTTOM: Borders = Borders(1 << 3)
-  /// Show the left border
+
+  /** Show the left border
+    */
   val LEFT: Borders = Borders(1 << 4)
-  /// Returns an empty set of flags.
+
+  /** Returns an empty set of flags.
+    */
   val EMPTY: Borders = Borders(bits = 0)
-  /// Show all borders
+
+  /** Show all borders
+    */
   val ALL: Borders = List(TOP, RIGHT, BOTTOM, LEFT).reduce(_ | _)
 }

--- a/tui/src/scala/tui/Cell.scala
+++ b/tui/src/scala/tui/Cell.scala
@@ -1,6 +1,7 @@
 package tui
 
-/// A buffer cell
+/** A buffer cell
+  */
 case class Cell(
     var symbol: tui.Grapheme,
     var fg: Color,

--- a/tui/src/scala/tui/CompletedFrame.scala
+++ b/tui/src/scala/tui/CompletedFrame.scala
@@ -1,8 +1,8 @@
 package tui
 
-/// CompletedFrame represents the state of the terminal after all changes performed in the last
-/// [`Terminal::draw`] call have been applied. Therefore, it is only valid until the next call to
-/// [`Terminal::draw`].
+/** CompletedFrame represents the state of the terminal after all changes performed in the last `Terminal.draw` call have been applied. Therefore, it is only
+  * valid until the next call to `Terminal.draw`.
+  */
 case class CompletedFrame(
     buffer: Buffer,
     area: Rect

--- a/tui/src/scala/tui/Frame.scala
+++ b/tui/src/scala/tui/Frame.scala
@@ -1,36 +1,35 @@
 package tui
 
-/// Represents a consistent terminal interface for rendering.
+/** Represents a consistent terminal interface for rendering.
+  * @param size
+  *   Terminal size, guaranteed not to change when rendering.
+  * @param cursor_position
+  *   Where should the cursor be after drawing this frame. If `None`, the cursor is hidden and its position is controlled by the backend. If `Some((x, /// y))`,
+  *   the cursor is shown and placed at `(x, y)` after the call to `Terminal.draw()`.
+  */
 case class Frame(
     buffer: Buffer,
-    /// Terminal size, guaranteed not to change when rendering.
     size: Rect,
-
-    /// Where should the cursor be after drawing this frame?
-    ///
-    /// If `None`, the cursor is hidden and its position is controlled by the backend. If `Some((x,
-    /// y))`, the cursor is shown and placed at `(x, y)` after the call to `Terminal::draw()`.
     var cursor_position: Option[(Int, Int)]
 ) {
 
-  /// Render a [`Widget`] to the current buffer using [`Widget::render`].
+  /** Render a [`Widget`] to the current buffer using [`Widget::render`].
+    */
   def render_widget(widget: Widget, area: Rect): Unit =
     widget.render(area, buffer)
 
-  /// Render a [`StatefulWidget`] to the current buffer using [`StatefulWidget::render`].
-  ///
-  /// The last argument should be an instance of the [`StatefulWidget::State`] associated to the
-  /// given [`StatefulWidget`].
-  ///
+  /** Render a `StatefulWidget` to the current buffer using `StatefulWidget.render`.
+    *
+    * The last argument should be an instance of the `StatefulWidget.State` associated to the given `StatefulWidget`.
+    */
   def render_stateful_widget[W <: StatefulWidget](widget: W, area: Rect)(state: widget.State): Unit =
     widget.render(area, buffer, state)
 
-  /// After drawing this frame, make the cursor visible and put it at the specified (x, y)
-  /// coordinates. If this method is not called, the cursor will be hidden.
-  ///
-  /// Note that this will interfere with calls to `Terminal::hide_cursor()`,
-  /// `Terminal::show_cursor()`, and `Terminal::set_cursor()`. Pick one of the APIs and stick
-  /// with it.
+  /** After drawing this frame, make the cursor visible and put it at the specified (x, y) coordinates. If this method is not called, the cursor will be hidden.
+    *
+    * Note that this will interfere with calls to `Terminal.hide_cursor()`, `Terminal.show_cursor()`, and `Terminal.set_cursor()`. Pick one of the APIs and
+    * stick with it.
+    */
   def set_cursor(x: Int, y: Int): Unit =
     cursor_position = Some((x, y))
 }

--- a/tui/src/scala/tui/Layout.scala
+++ b/tui/src/scala/tui/Layout.scala
@@ -8,12 +8,16 @@ import tui.internal.ranges
 
 import scala.collection.mutable
 
+/** @param direction
+  * @param margin
+  * @param constraints
+  *   Whether the last chunk of the computed layout should be expanded to fill the available space.
+  * @param expand_to_fill
+  */
 case class Layout(
     direction: Direction = Direction.Vertical,
     margin: Margin = Margin(horizontal = 0, vertical = 0),
     constraints: Array[Constraint] = Array.empty,
-    /// Whether the last chunk of the computed layout should be expanded to fill the available
-    /// space.
     expand_to_fill: Boolean = true
 ) {
   def split(area: Rect): Array[Rect] =
@@ -23,7 +27,8 @@ case class Layout(
 object Layout {
   val LAYOUT_CACHE = mutable.HashMap.empty[(Rect, Layout), Array[Rect]]
 
-  /// A container used by the solver inside split
+  /** A container used by the solver inside split
+    */
   case class Element(
       x: Variable = Variable(),
       y: Variable = Variable(),

--- a/tui/src/scala/tui/Modifier.scala
+++ b/tui/src/scala/tui/Modifier.scala
@@ -1,10 +1,9 @@
 package tui
 
-/*  Modifier changes the way a piece of text is displayed.
- *
- *  They are bitflags so they can easily be composed.
- *
- */
+/** Modifier changes the way a piece of text is displayed.
+  *
+  * They are bitflags so they can easily be composed.
+  */
 case class Modifier(bits: Int) {
   def fmt(sb: StringBuilder): Unit = {
     var first = true
@@ -83,15 +82,18 @@ case class Modifier(bits: Int) {
     sb.toString()
   }
 
-  /// Returns `true` if all of the flags in `other` are contained within `self`.
+  /** Returns `true` if all of the flags in `other` are contained within `self`.
+    */
   def contains(other: Modifier): Boolean =
     other != Modifier.EMPTY && (bits & other.bits) == other.bits
 
-  /// Inserts the specified flags in-place.
+  /** Inserts the specified flags in-place.
+    */
   def insert(other: Modifier): Modifier =
     copy(bits = bits | other.bits)
 
-  /// Removes the specified flags in-place.
+  /** Removes the specified flags in-place.
+    */
   def remove(other: Modifier): Modifier =
     copy(bits = bits & ~other.bits)
 

--- a/tui/src/scala/tui/Rect.scala
+++ b/tui/src/scala/tui/Rect.scala
@@ -1,7 +1,7 @@
 package tui
 
-/// A simple rectangle used in the computation of the layout and to give widgets a hint about the
-/// area they are supposed to render to.
+/** A simple rectangle used in the computation of the layout and to give widgets a hint about the area they are supposed to render to.
+  */
 case class Rect(
     x: Int,
     y: Int,

--- a/tui/src/scala/tui/Span.scala
+++ b/tui/src/scala/tui/Span.scala
@@ -2,16 +2,18 @@ package tui
 
 import tui.internal.UnicodeSegmentation
 
-/// A string where all graphemes have the same style.
+/** string where all graphemes have the same style.
+  */
 case class Span(content: String, style: Style) {
-  /// Returns the width of the content held by this span.
+
+  /** Returns the width of the content held by this span.
+    */
   def width: Int = content.length
 
-  /// Returns an iterator over the graphemes held by this span.
-  ///
-  /// `base_style` is the [`Style`] that will be patched with each grapheme [`Style`] to get
-  /// the resulting [`Style`].
-  ///
+  /** Returns an iterator over the graphemes held by this span.
+    *
+    * `base_style` is the `Style` that will be patched with each grapheme `Style` to get the resulting `Style`.
+    */
   def styled_graphemes(base_style: Style): Array[StyledGrapheme] =
     UnicodeSegmentation
       .graphemes(content, is_extended = true)
@@ -25,12 +27,14 @@ case class Span(content: String, style: Style) {
 }
 
 object Span {
-  /// Create a span with no style.
-  ///
+
+  /** Create a span with no style.
+    */
   def nostyle(content: String): Span =
     Span(content = content, style = Style())
 
-  /// Create a span with a style.
+  /** Create a span with a style.
+    */
   def styled(content: String, style: Style): Span =
     Span(content = content, style)
 }

--- a/tui/src/scala/tui/StatefulWidget.scala
+++ b/tui/src/scala/tui/StatefulWidget.scala
@@ -1,20 +1,15 @@
 package tui
 
-/// A `StatefulWidget` is a widget that can take advantage of some local state to remember things
-/// between two draw calls.
-///
-/// Most widgets can be drawn directly based on the input parameters. However, some features may
-/// require some kind of associated state to be implemented.
-///
-/// For example, the [`List`] widget can highlight the item currently selected. This can be
-/// translated in an offset, which is the number of elements to skip in order to have the selected
-/// item within the viewport currently allocated to this widget. The widget can therefore only
-/// provide the following behavior: whenever the selected item is out of the viewport scroll to a
-/// predefined position (making the selected item the last viewable item or the one in the middle
-/// for example). Nonetheless, if the widget has access to the last computed offset then it can
-/// implement a natural scrolling experience where the last offset is reused until the selected
-/// item is out of the viewport.
-///
+/** A `StatefulWidget` is a widget that can take advantage of some local state to remember things between two draw calls.
+  *
+  * Most widgets can be drawn directly based on the input parameters. However, some features may require some kind of associated state to be implemented.
+  *
+  * For example, the `List` widget can highlight the item currently selected. This can be translated in an offset, which is the number of elements to skip in
+  * order to have the selected item within the viewport currently allocated to this widget. The widget can therefore only provide the following behavior:
+  * whenever the selected item is out of the viewport scroll to a predefined position (making the selected item the last viewable item or the one in the middle
+  * for example). Nonetheless, if the widget has access to the last computed offset then it can implement a natural scrolling experience where the last offset
+  * is reused until the selected item is out of the viewport.
+  */
 trait StatefulWidget {
   type State
 

--- a/tui/src/scala/tui/Style.scala
+++ b/tui/src/scala/tui/Style.scala
@@ -1,47 +1,51 @@
 package tui
 
-//! `style` contains the primitives used to control how your user interface will look.
-
-/// Style let you control the main characteristics of the displayed elements.
-///
-/// It represents an incremental change. If you apply the styles S1, S2, S3 to a cell of the
-/// terminal buffer, the style of this cell will be the result of the merge of S1, S2 and S3, not
-/// just S3.
-///
+/** `style` contains the primitives used to control how your user interface will look.
+  *
+  * Style let you control the main characteristics of the displayed elements.
+  *
+  * It represents an incremental change. If you apply the styles S1, S2, S3 to a cell of the terminal buffer, the style of this cell will be the result of the
+  * merge of S1, S2 and S3, not just S3.
+  */
 case class Style(
     fg: Option[Color] = None,
     bg: Option[Color] = None,
     add_modifier: Modifier = Modifier.EMPTY,
     sub_modifier: Modifier = Modifier.EMPTY
 ) {
-  /// Changes the foreground color.
+
+  /** Changes the foreground color.
+    */
   def fg(color: Color): Style =
     copy(fg = Some(color))
 
-  /// Changes the background color.
+  /** Changes the background color.
+    */
   def bg(color: Color): Style =
     copy(bg = Some(color))
 
-  /// Changes the text emphasis.
-  ///
-  /// When applied, it adds the given modifier to the `Style` modifiers.
+  /** Changes the text emphasis.
+    *
+    * When applied, it adds the given modifier to the `Style` modifiers.
+    */
   def add_modifier(modifier: Modifier): Style =
     copy(
       sub_modifier = sub_modifier.remove(modifier),
       add_modifier = add_modifier.insert(modifier)
     )
 
-  /// Changes the text emphasis.
-  ///
-  /// When applied, it removes the given modifier from the `Style` modifiers.
+  /** Changes the text emphasis.
+    *
+    * When applied, it removes the given modifier from the `Style` modifiers.
+    */
   def remove_modifier(modifier: Modifier): Style =
     copy(
       add_modifier = add_modifier.remove(modifier),
       sub_modifier = sub_modifier.insert(modifier)
     )
 
-  /// Results in a combined style that is equivalent to applying the two individual styles to
-  /// a style one after the other.
+  /** Results in a combined style that is equivalent to applying the two individual styles to a style one after the other.
+    */
   def patch(other: Style): Style =
     Style(
       fg = other.fg.orElse(this.fg),
@@ -54,7 +58,8 @@ case class Style(
 object Style {
   val DEFAULT: Style = Style()
 
-  /// Returns a `Style` resetting all properties.
+  /** Returns a `Style` resetting all properties.
+    */
   val RESET: Style = Style(
     fg = Some(Color.Reset),
     bg = Some(Color.Reset),

--- a/tui/src/scala/tui/StyledGrapheme.scala
+++ b/tui/src/scala/tui/StyledGrapheme.scala
@@ -1,6 +1,7 @@
 package tui
 
-/// A grapheme associated to a style.
+/** A grapheme associated to a style.
+  */
 case class StyledGrapheme(
     symbol: Grapheme,
     style: Style

--- a/tui/src/scala/tui/Terminal.scala
+++ b/tui/src/scala/tui/Terminal.scala
@@ -2,17 +2,23 @@ package tui
 
 import scala.util.control.NonFatal
 
-/// Interface to the terminal backed by Termion
+/** Interface to the terminal backed by Termion
+  *
+  * @param backend
+  * @param buffers
+  *   Holds the results of the current and previous draw calls. The two are compared at the end of each draw pass to output the necessary updates to the
+  *   terminal
+  * @param current
+  *   Index of the current buffer in the previous array
+  * @param hidden_cursor
+  *   Whether the cursor is currently hidden
+  * @param viewport
+  */
 case class Terminal private (
     backend: Backend,
-    /// Holds the results of the current and previous draw calls. The two are compared at the end
-    /// of each draw pass to output the necessary updates to the terminal
     buffers: Array[Buffer],
-    /// Index of the current buffer in the previous array
     var current: Int,
-    /// Whether the cursor is currently hidden
     var hidden_cursor: Boolean,
-    /// Viewport
     viewport: Viewport
 ) {
   require(buffers.length == 2)
@@ -25,7 +31,9 @@ case class Terminal private (
         case NonFatal(e) => System.err.println(s"Failed to show the cursor: ${e.getMessage}")
       }
     }
-  /// Get a Frame object which provides a consistent view into the terminal state for rendering.
+
+  /** Get a Frame object which provides a consistent view into the terminal state for rendering.
+    */
   def get_frame(): Frame =
     Frame(
       buffer = current_buffer_mut(),
@@ -36,8 +44,8 @@ case class Terminal private (
   def current_buffer_mut(): Buffer =
     buffers(current)
 
-  /// Obtains a difference between the previous and the current buffer and passes it to the
-  /// current backend for drawing.
+  /** Obtains a difference between the previous and the current buffer and passes it to the current backend for drawing.
+    */
   def flush(): Unit = {
     val previous_buffer = buffers(1 - current)
     val current_buffer = buffers(current)
@@ -45,9 +53,9 @@ case class Terminal private (
     backend.draw(updates)
   }
 
-  /// Updates the Terminal so that internal buffers match the requested size. Requested size will
-  /// be saved so the size can remain consistent when rendering.
-  /// This leads to a full clear of the screen.
+  /** Updates the Terminal so that internal buffers match the requested size. Requested size will be saved so the size can remain consistent when rendering.
+    * This leads to a full clear of the screen.
+    */
   def resize(area: Rect): Unit = {
     buffers(current).resize(area)
     buffers(1 - current).resize(area)
@@ -55,7 +63,8 @@ case class Terminal private (
     clear()
   }
 
-  /// Queries the backend for size and resizes if it doesn't match the previous size.
+  /** Queries the backend for size and resizes if it doesn't match the previous size.
+    */
   def autoresize(): Unit =
     if (viewport.resize_behavior == ResizeBehavior.Auto) {
       val size_ = size()
@@ -64,8 +73,8 @@ case class Terminal private (
       }
     }
 
-  /// Synchronizes terminal size, calls the rendering closure, flushes the current internal state
-  /// and prepares for the next draw call.
+  /** Synchronizes terminal size, calls the rendering closure, flushes the current internal state and prepares for the next draw call.
+    */
   def draw(f: Frame => Unit): CompletedFrame = {
     // Autoresize - otherwise we get glitches if shrinking or potential desync between widgets
     // and the terminal (if growing), which may OOB.
@@ -116,21 +125,24 @@ case class Terminal private (
   def set_cursor(x: Int, y: Int): Unit =
     backend.set_cursor(x, y)
 
-  /// Clear the terminal and force a full redraw on the next draw call.
+  /** Clear the terminal and force a full redraw on the next draw call.
+    */
   def clear(): Unit = {
     backend.clear()
     // Reset the back buffer to make sure the next update will redraw everything.
     buffers(1 - current).reset()
   }
 
-  /// Queries the real size of the backend.
+  /** Queries the real size of the backend.
+    */
   def size(): Rect =
     backend.size()
 }
 
 object Terminal {
-  /// Wrapper around Terminal initialization. Each buffer is initialized with a blank string and
-  /// default colors for the foreground and the background
+
+  /** Wrapper around Terminal initialization. Each buffer is initialized with a blank string and default colors for the foreground and the background
+    */
   def init(backend: Backend): Terminal = {
 
     val size = backend.size()

--- a/tui/src/scala/tui/TerminalOptions.scala
+++ b/tui/src/scala/tui/TerminalOptions.scala
@@ -1,7 +1,9 @@
 package tui
 
-/// Options to pass to [`Terminal::with_options`]
+/** Options to pass to `Terminal.with_options`
+  * @param viewport
+  *   Viewport used to draw to the terminal
+  */
 case class TerminalOptions(
-    /// Viewport used to draw to the terminal
     viewport: Viewport
 )

--- a/tui/src/scala/tui/Text.scala
+++ b/tui/src/scala/tui/Text.scala
@@ -3,47 +3,44 @@ package tui
 import scala.collection.Factory
 import scala.jdk.StreamConverters.StreamHasToScala
 
-//! Primitives for styled text.
-//!
-//! A terminal UI is at its root a lot of strings. In order to make it accessible and stylish,
-//! those strings may be associated to a set of styles. `tui` has three ways to represent them:
-//! - A single line string where all graphemes have the same style is represented by a [`Span`].
-//! - A single line string where each grapheme may have its own style is represented by [`Spans`].
-//! - A multiple line string where each grapheme may have its own style is represented by a
-//! [`Text`].
-//!
-//! These types form a hierarchy: [`Spans`] is a collection of [`Span`] and each line of [`Text`]
-//! is a [`Spans`].
-//!
-//! Keep it mind that a lot of widgets will use those types to advertise what kind of string is
-//! supported for their properties. Moreover, `tui` provides convenient `From` implementations so
-//! that you can start by using simple `String` or `&str` and then promote them to the previous
-//! primitives when you need additional styling capabilities.
-//!
-//! For example, for the [`crate::widgets::Block`] widget, all the following calls are valid to set
-//! its `title` property (which is a [`Spans`] under the hood):
-//!
-
-/// A string split over multiple lines where each line is composed of several clusters, each with
-/// their own style.
-///
-/// A [`Text`], like a [`Span`], can be constructed using one of the many `From` implementations
-/// or via the [`Text::raw`] and [`Text::styled`] methods. Helpfully, [`Text`] also implements
-/// [`core::iter::Extend`] which enables the concatenation of several [`Text`] blocks.
+/** Primitives for styled text.
+  *
+  * A terminal UI is at its root a lot of strings. In order to make it accessible and stylish, those strings may be associated to a set of styles. `tui` has
+  * three ways to represent them:
+  *   - A single line string where all graphemes have the same style is represented by a `Span`.
+  *   - A single line string where each grapheme may have its own style is represented by `Spans`.
+  *   - A multiple line string where each grapheme may have its own style is represented by a `Text`.
+  *
+  * These types form a hierarchy: `Spans` is a collection of `Span` and each line of `Text` is a `Spans`.
+  *
+  * Keep it mind that a lot of widgets will use those types to advertise what kind of string is supported for their properties. Moreover, `tui` provides
+  * convenient `From` implementations so that you can start by using simple `String` or `&str` and then promote them to the previous primitives when you need
+  * additional styling capabilities.
+  *
+  * For example, for the `Block` widget, all the following calls are valid to set its `title` property (which is a `Spans` under the hood):
+  *
+  * A string split over multiple lines where each line is composed of several clusters, each with their own style.
+  *
+  * A `Text`, like a `Span`, can be constructed using one of the many `From` implementations or via the `Text.unstyled` and `Text.styled` methods. Helpfully,
+  * `Text` also implements `Extend` which enables the concatenation of several `Text` blocks.
+  */
 case class Text(lines: Array[Spans]) {
 
-  /// Returns the max width of all the lines.
+  /** Returns the max width of all the lines.
+    */
   def width: Int =
     lines
       .map(_.width)
       .maxOption
       .getOrElse(0)
 
-  /// Returns the height.
+  /** Returns the height.
+    */
   def height: Int =
     lines.length
 
-  /// Apply a new style to existing text.
+  /** Apply a new style to existing text.
+    */
   def overwrittenStyle(style: Style): Text =
     Text(lines.map { case Spans(spans) =>
       Spans(spans.map { span =>
@@ -53,7 +50,9 @@ case class Text(lines: Array[Spans]) {
 }
 
 object Text {
-  /// Create some text (potentially multiple lines) with no style.
+
+  /** Create some text (potentially multiple lines) with no style.
+    */
   def nostyle(content: String): Text =
     Text(content.lines().map(Spans.nostyle).toScala(Factory.arrayFactory[Spans]))
   def from(span: Span): Text =

--- a/tui/src/scala/tui/Widget.scala
+++ b/tui/src/scala/tui/Widget.scala
@@ -1,8 +1,10 @@
 package tui
 
-/// Base requirements for a Widget
+/** Base requirements for a Widget
+  */
 trait Widget {
-  /// Draws the current state of the widget in the given buffer. That is the only method required
-  /// to implement a custom widget.
+
+  /** Draws the current state of the widget in the given buffer. That is the only method required to implement a custom widget.
+    */
   def render(area: Rect, buf: Buffer): Unit
 }

--- a/tui/src/scala/tui/symbols.scala
+++ b/tui/src/scala/tui/symbols.scala
@@ -222,17 +222,22 @@ object symbols {
     )
   }
 
-/// Marker to use when plotting data points
+  /** Marker to use when plotting data points
+    */
   sealed trait Marker
 
   object Marker {
-    /// One point per cell in shape of dot
+
+    /** One point per cell in shape of dot
+      */
     case object Dot extends Marker
 
-    /// One point per cell in shape of a block
+    /** One point per cell in shape of a block
+      */
     case object Block extends Marker
 
-    /// Up to 8 points per cell
+    /** Up to 8 points per cell
+      */
     case object Braille extends Marker
   }
 }


### PR DESCRIPTION
I saw in #15 you mentioned _scala-ifying_ things, so I figured one part of that could be making the docs actual valid scaladoc. This will be nice for users even when using autocomplete to get the docs showing up.