### PR TITLE
Remove need to workaround jni library path for native image (fixes #28)

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -1,13 +1,13 @@
 $schema: https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json
 $version: 0.0.1-M25
 jvm:
-  name: zulu:17.0.1
+  name: graalvm-java17:22.3.1
 projects:
   cassowary:
     extends: template-cross-scala
   crossterm: {}
   demo:
-    dependencies: org.graalvm.nativeimage:svm:22.3.0
+    dependencies: org.graalvm.nativeimage:svm:22.3.1
     dependsOn: tui
     extends: template-cross-scala
     platform:

--- a/crossterm/src/java/tui/crossterm/NativeLoader.java
+++ b/crossterm/src/java/tui/crossterm/NativeLoader.java
@@ -12,18 +12,9 @@ class NativeLoader {
         }
     }
 
-    static String withPlatformName(String lib) {
-        if (System.getProperty("org.graalvm.nativeimage.imagecode") != null)
-            return "/" + lib;
-        else {
-            String plat = getPlatform();
-            return "/native/" + plat + "/" + lib;
-        }
-    }
-
     static void loadPackaged(String nativeLibrary) throws Exception {
-        String lib = System.mapLibraryName(nativeLibrary);
-        var resourcePath = withPlatformName(lib);
+        String lib = System.mapLibraryName("native-" + getPlatform() + "-" + nativeLibrary);
+        var resourcePath = "/" + lib;
         var resourceStream = NativeLoader.class.getResourceAsStream(resourcePath);
         if (resourceStream == null) {
             throw new UnsatisfiedLinkError(

--- a/scripts/src/scala/tui/scripts/GenNativeImage.scala
+++ b/scripts/src/scala/tui/scripts/GenNativeImage.scala
@@ -23,6 +23,9 @@ object GenNativeImage extends BleepScript("GenNativeImage") {
         "--initialize-at-build-time=scala.Symbol$",
         "--native-image-info",
         """-H:IncludeResources=libnative-arm64-darwin-crossterm.dylib""",
+        """-H:IncludeResources=libnative-x86_64-darwin-crossterm.dylib""",
+        """-H:IncludeResources=libnative-x86_64-linux-crossterm.so""",
+        """-H:IncludeResources=native-x86_64-windows-crossterm.dll""",
         "-H:-UseServiceLoaderFeature"
       ),
       jvmCommand = started.jvmCommand,

--- a/scripts/src/scala/tui/scripts/GenNativeImage.scala
+++ b/scripts/src/scala/tui/scripts/GenNativeImage.scala
@@ -3,18 +3,13 @@ package tui.scripts
 import bleep._
 import bleep.plugin.nativeimage.NativeImagePlugin
 
-import java.nio.file.{Files, Path, StandardCopyOption}
+import java.nio.file.Path
 
 object GenNativeImage extends BleepScript("GenNativeImage") {
   def run(started: Started, commands: Commands, args: List[String]): Unit = {
     commands.compile(List(demoProject))
 
-    val jniLibraryPath = GenJniLibrary.crosstermJniNativeLib(started).nativeCompile()
-
-    val newJniLibraryPath = started.projectPaths(demoProject).resourcesDirs.generated / jniLibraryPath.getFileName.toString
-    Files.createDirectories(newJniLibraryPath.getParent)
-    Files.copy(jniLibraryPath, newJniLibraryPath, StandardCopyOption.REPLACE_EXISTING)
-    started.logger.info(s"workaround for https://github.com/oracle/graal/issues/5219 : copy $jniLibraryPath to $newJniLibraryPath")
+    GenJniLibrary.crosstermJniNativeLib(started).nativeCompile()
 
     val plugin = new NativeImagePlugin(
       project = started.bloopProjects(demoProject),
@@ -27,7 +22,7 @@ object GenNativeImage extends BleepScript("GenNativeImage") {
         "--initialize-at-build-time=scala.Symbol",
         "--initialize-at-build-time=scala.Symbol$",
         "--native-image-info",
-        """-H:IncludeResources=libcrossterm.dylib""",
+        """-H:IncludeResources=libnative-arm64-darwin-crossterm.dylib""",
         "-H:-UseServiceLoaderFeature"
       ),
       jvmCommand = started.jvmCommand,


### PR DESCRIPTION
There is a long-standing bug involving resources in nested directories with graalvm. not sure why this doesn't affect everybody out there, including the sbt plugin where the naming standard comes from.

Anyway, let's change the mapping so instead of `$native/$platform/libname` we say `$native_$platform_libname`.
 For arm64/macOs it looks like this `libnative-arm64-darwin-crossterm.dylib`.

 That should hopefully sort it out.