### PR TITLE
React-style layer hits a milestone: working app, lots of polish, new components

### DIFF
--- a/jatatui-components/src/java/jatatui/components/Components.java
+++ b/jatatui-components/src/java/jatatui/components/Components.java
@@ -9,8 +9,14 @@ import jatatui.components.list.ListProps;
 import jatatui.components.dropdown.Dropdown;
 import jatatui.components.dropdown.DropdownProps;
 import jatatui.components.form.FormProvider;
+import jatatui.components.button.Button;
+import jatatui.components.chrome.BackButton;
+import jatatui.components.chrome.ScreenFrame;
+import jatatui.components.link.Link;
+import jatatui.components.modal.ConfirmDialog;
 import jatatui.components.modal.Modal;
 import jatatui.components.modal.ModalProps;
+import jatatui.components.scrollable.Scrollable;
 import jatatui.components.picker.Picker;
 import jatatui.components.picker.PickerProps;
 import jatatui.components.selectablelist.SelectableList;
@@ -213,6 +219,75 @@ public final class Components {
   /// Quick-path: open + title + body + onDismiss. 40x12 default size.
   public static Element modal(boolean open, String title, Element body, Runnable onDismiss) {
     return Modal.of(ModalProps.of(open, title, body, onDismiss));
+  }
+
+  // ---------- Button ----------
+
+  /// Bordered, Tab-focusable button. Enter or click activates. `primary=true` is intended for
+  /// the dominant action on a form.
+  public static Element button(String label, String focusId, boolean primary, Runnable onClick) {
+    return Button.of(label, focusId, primary, onClick);
+  }
+
+  // ---------- Chrome (BackButton + ScreenFrame) ----------
+
+  /// "← label" chip in the upper-left. Clickable; not Tab-focusable (host owns the Esc / b
+  /// keyboard binding).
+  public static Element backButton(String label, Runnable back) {
+    return BackButton.of(label, back);
+  }
+
+  /// Standard top-of-screen chrome: BackButton + gutter + content.
+  public static Element screenFrame(String backLabel, Runnable back, Element content) {
+    return ScreenFrame.of(backLabel, back, content);
+  }
+
+  /// Variant with a brand/title strip alongside the back button.
+  public static Element screenFrame(
+      String backLabel, Runnable back, Element title, Element content) {
+    return ScreenFrame.withTitle(backLabel, back, title, content);
+  }
+
+  // ---------- ConfirmDialog ----------
+
+  /// Yes/No confirmation modal. `danger=true` paints the box red for destructive actions.
+  public static Element confirmDialog(
+      boolean open,
+      String title,
+      String message,
+      String confirmLabel,
+      String cancelLabel,
+      boolean danger,
+      Runnable onConfirm,
+      Runnable onCancel) {
+    return ConfirmDialog.of(
+        open, title, message, confirmLabel, cancelLabel, danger, onConfirm, onCancel);
+  }
+
+  // ---------- Link ----------
+
+  /// Focusable + clickable activation target. `onActivate` runs on Enter (when focused) or on
+  /// click. The most common use is `() -> router.push(screen)`, but any Runnable works.
+  public static Element link(
+      boolean autoFocus, Runnable onActivate, java.util.function.Function<Boolean, Element> content) {
+    return Link.focusable(autoFocus, onActivate, content);
+  }
+
+  /// Link with an explicit focus id.
+  public static Element link(
+      String focusId,
+      boolean autoFocus,
+      Runnable onActivate,
+      java.util.function.Function<Boolean, Element> content) {
+    return Link.focusable(focusId, autoFocus, onActivate, content);
+  }
+
+  // ---------- Scrollable ----------
+
+  /// Wheel-scrollable column. Max offset clamped against the assigned area's height. For
+  /// selectable lists where Up/Down should move selection, use [#selectableList] instead.
+  public static Element scrollable(java.util.List<Element> children) {
+    return Scrollable.column(children);
   }
 
   // ---------- Picker ----------

--- a/jatatui-components/src/java/jatatui/components/Components.java
+++ b/jatatui-components/src/java/jatatui/components/Components.java
@@ -238,11 +238,13 @@ public final class Components {
   // ---------- Dropdown ----------
 
   /// Full-control dropdown / select. See [DropdownProps].
-  public static Element dropdown(DropdownProps props) {
+  public static <T> Element dropdown(DropdownProps<T> props) {
     return Dropdown.of(props);
   }
 
-  /// Quick-path: label + items + selected + onChange + focusId.
+  /// Quick-path for the common `List<String>` case: label + items + selected + onChange +
+  /// focusId. Auto-focused. For typed options (enums, records), build a [DropdownProps] via
+  /// [DropdownProps#of] with a `labelFn` and pass it to [#dropdown(DropdownProps)].
   public static Element dropdown(
       String label,
       List<String> items,
@@ -250,7 +252,9 @@ public final class Components {
       java.util.function.IntConsumer onChange,
       String focusId) {
     return Dropdown.of(
-        DropdownProps.of(label, items, selectedIndex, onChange).withFocusId(focusId).withAutoFocus(true));
+        DropdownProps.ofStrings(label, items, selectedIndex, onChange)
+            .withFocusId(focusId)
+            .withAutoFocus(true));
   }
 
   // ---------- TextInput ----------

--- a/jatatui-components/src/java/jatatui/components/Components.java
+++ b/jatatui-components/src/java/jatatui/components/Components.java
@@ -11,6 +11,10 @@ import jatatui.components.dropdown.DropdownProps;
 import jatatui.components.form.FormProvider;
 import jatatui.components.modal.Modal;
 import jatatui.components.modal.ModalProps;
+import jatatui.components.picker.Picker;
+import jatatui.components.picker.PickerProps;
+import jatatui.components.selectablelist.SelectableList;
+import jatatui.components.selectablelist.SelectableListProps;
 import jatatui.components.router.Router;
 import jatatui.components.router.Screen;
 import jatatui.components.theme.Theme;
@@ -209,6 +213,26 @@ public final class Components {
   /// Quick-path: open + title + body + onDismiss. 40x12 default size.
   public static Element modal(boolean open, String title, Element body, Runnable onDismiss) {
     return Modal.of(ModalProps.of(open, title, body, onDismiss));
+  }
+
+  // ---------- Picker ----------
+
+  /// Search-input + ranked-list modal. See [PickerProps]. Host renders this conditionally
+  /// (when their search hotkey fires); the picker owns query / cursor state and the modal
+  /// chrome but doesn't auto-close — the host decides whether `onSelect` / `onCancel` should
+  /// hide it.
+  public static <T> Element picker(PickerProps<T> props) {
+    return Picker.of(props);
+  }
+
+  // ---------- SelectableList ----------
+
+  /// Heterogeneous-row list with skip-non-activatable Up/Down navigation. See
+  /// [SelectableListProps]. Sibling of [#list] (which takes labelled strings); this one takes
+  /// arbitrary Elements per row plus a predicate that controls which rows participate in
+  /// keyboard / click navigation.
+  public static <T> Element selectableList(SelectableListProps<T> props) {
+    return SelectableList.of(props);
   }
 
   // ---------- Dropdown ----------

--- a/jatatui-components/src/java/jatatui/components/button/Button.java
+++ b/jatatui-components/src/java/jatatui/components/button/Button.java
@@ -1,0 +1,62 @@
+package jatatui.components.button;
+
+import static jatatui.react.Components.*;
+
+import jatatui.core.style.Color;
+import jatatui.core.style.Modifier;
+import jatatui.core.style.Style;
+import jatatui.core.text.Line;
+import jatatui.core.text.Span;
+import jatatui.core.widgets.Widget;
+import jatatui.react.Element;
+import jatatui.widgets.Borders;
+import jatatui.widgets.block.Block;
+import jatatui.widgets.block.BorderType;
+import jatatui.widgets.paragraph.Paragraph;
+import java.util.Optional;
+import tui.crossterm.KeyCode;
+
+/// Bordered, Tab-focusable button. Enter (when focused) or mouse click activates.
+///
+/// Two visual variants via [#primary]:
+///   - `true` — green border, intended for the dominant action on a form ("Save", "Confirm")
+///   - `false` — gray border, secondary actions ("Cancel", "Back")
+///
+/// When focused the border switches to the thick variant + cyan, so the user can tell at a
+/// glance which button Enter would activate.
+public final class Button {
+  private Button() {}
+
+  /// Build a button. `focusId` participates in the FocusManager — pick something stable so
+  /// imperative `ctx.focus(id)` works and Tab order is predictable.
+  public static Element of(String label, String focusId, boolean primary, Runnable onClick) {
+    return component(
+        ctx -> {
+          boolean focused = ctx.useFocus(Optional.of(focusId), false);
+
+          if (focused) ctx.onKey(new KeyCode.Enter(), onClick::run);
+          ctx.onClick(e -> onClick.run());
+
+          Color accent = primary ? new Color.Green() : new Color.Gray();
+          BorderType borderType = focused ? BorderType.Thick : BorderType.Rounded;
+          Style borderStyle = Style.empty().withFg(focused ? new Color.Cyan() : accent);
+          Style textStyle =
+              Style.empty()
+                  .withFg(focused ? new Color.White() : accent)
+                  .withAddModifier(Modifier.BOLD);
+
+          Widget w =
+              (area, buffer) -> {
+                Block block =
+                    Block.empty()
+                        .withBorders(Borders.ALL)
+                        .withBorderType(borderType)
+                        .withBorderStyle(borderStyle);
+                Paragraph.of(Line.from(Span.styled("  " + label, textStyle)))
+                    .withBlock(block)
+                    .render(area, buffer);
+              };
+          return widget(w);
+        });
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/chrome/BackButton.java
+++ b/jatatui-components/src/java/jatatui/components/chrome/BackButton.java
@@ -1,0 +1,86 @@
+package jatatui.components.chrome;
+
+import static jatatui.react.Components.*;
+
+import jatatui.core.layout.Rect;
+import jatatui.core.style.Color;
+import jatatui.core.style.Style;
+import jatatui.core.widgets.Widget;
+import jatatui.react.Element;
+import jatatui.widgets.Borders;
+import jatatui.widgets.block.Block;
+import jatatui.widgets.block.BorderType;
+import jatatui.widgets.paragraph.Paragraph;
+
+/// Bordered "← label" chip anchored to the top-left of its assigned area. Clickable; not
+/// Tab-focusable on purpose — the keyboard binding (Esc / b / whatever) lives on the host
+/// screen so it can compose with screen-local state. This component is the visual half.
+///
+/// Height: [#HEIGHT] cells (3 = top border + content + bottom border).
+/// Width: roughly `label.length + 5` (`" ← " + label + 2 borders`). Anything past the chip on
+/// the right side is left blank — pair with `length(BackButton.HEIGHT, ...)` in a column and
+/// drop additional chrome alongside it.
+///
+/// On click, the component blurs focus before invoking `back` so the destination screen's
+/// first `useFocus(autoFocus=true)` claims same-frame via the eager-claim path. Without this,
+/// the destination would flash one frame with stale focus before commit re-picks.
+public final class BackButton {
+  private BackButton() {}
+
+  /// Standard height of the chip in cells.
+  public static final int HEIGHT = 3;
+
+  public static Element of(String label, Runnable back) {
+    return component(
+        ctx -> {
+          int buttonWidth = label.length() + 5; // "← " + label + 2 borders + 1 space
+
+          // Restrict the click target to the visible chip — clicks past the right edge fall
+          // through to whatever's underneath.
+          ctx.area()
+              .ifPresent(
+                  a -> {
+                    int width = Math.min(buttonWidth, a.width());
+                    Rect hit =
+                        new Rect(a.x(), a.y(), width, Math.min(HEIGHT, a.height()));
+                    ctx.onClick(
+                        hit,
+                        e -> {
+                          ctx.blur();
+                          back.run();
+                        });
+                  });
+
+          Style borderStyle = Style.empty().withFg(new Color.Gray());
+          Style textStyle = Style.empty().withFg(new Color.Gray());
+          Style hintStyle = Style.empty().withFg(new Color.DarkGray());
+
+          Widget w =
+              (area, buffer) -> {
+                int width = Math.min(buttonWidth, area.width());
+                if (width <= 0 || area.height() <= 0) return;
+                Rect buttonArea =
+                    new Rect(area.x(), area.y(), width, Math.min(HEIGHT, area.height()));
+
+                Block block =
+                    Block.empty()
+                        .withBorders(Borders.ALL)
+                        .withBorderType(BorderType.Rounded)
+                        .withBorderStyle(borderStyle);
+                block.render(buttonArea, buffer);
+
+                Paragraph.of(" ← " + label)
+                    .withStyle(textStyle)
+                    .render(block.inner(buttonArea), buffer);
+
+                int hintX = buttonArea.x() + buttonArea.width() + 1;
+                int hintRoom = area.x() + area.width() - hintX;
+                if (hintRoom >= 5 && area.height() >= 2) {
+                  Rect hintArea = new Rect(hintX, area.y() + 1, Math.min(5, hintRoom), 1);
+                  Paragraph.of("(esc)").withStyle(hintStyle).render(hintArea, buffer);
+                }
+              };
+          return widget(w);
+        });
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/chrome/ScreenFrame.java
+++ b/jatatui-components/src/java/jatatui/components/chrome/ScreenFrame.java
@@ -1,0 +1,37 @@
+package jatatui.components.chrome;
+
+import static jatatui.react.Components.*;
+
+import jatatui.react.Element;
+
+/// Standard top-of-screen chrome: a [BackButton] chip in the upper-left, a blank gutter line,
+/// then `content` filling the rest of the area.
+///
+/// Tab order is unaffected — BackButton is intentionally non-focusable, so the focus chain
+/// starts with whatever focusable `content` registers first.
+public final class ScreenFrame {
+  private ScreenFrame() {}
+
+  public static Element of(String backLabel, Runnable back, Element content) {
+    return component(
+        ctx ->
+            column(
+                length(BackButton.HEIGHT, BackButton.of(backLabel, back)),
+                length(1, empty()),
+                fill(1, content)));
+  }
+
+  /// Variant with a brand/title strip next to the back button (e.g. main-menu header). The
+  /// back chip is fixed-width on the left; the title fills the remainder.
+  public static Element withTitle(
+      String backLabel, Runnable back, Element title, Element content) {
+    return component(
+        ctx ->
+            column(
+                length(
+                    BackButton.HEIGHT,
+                    row(length(20, BackButton.of(backLabel, back)), fill(1, title))),
+                length(1, empty()),
+                fill(1, content)));
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
@@ -32,8 +32,16 @@ public final class Dropdown {
           boolean open = openState.get();
 
           // Auto-close when focus moves elsewhere — Tab to next field, programmatic focus
-          // change, etc. The backdrop closes on outside click; this catches every other path.
+          // change, etc. Commits the current highlight as the selection: keyboard navigation
+          // ending in Tab is "I picked this, move on". Mouse-outside-click goes through the
+          // backdrop's onClick which clears openState directly (bypassing this branch), so
+          // cancel-by-click-outside still works without committing. Esc is similar: its onKey
+          // handler clears openState before this branch can run.
           if (open && !focused) {
+            int hi = clamp(highlightState.get(), 0, Math.max(0, props.items().size() - 1));
+            if (hi != props.selectedIndex()) {
+              props.onChange().accept(hi);
+            }
             openState.set(false);
             open = false;
           }

--- a/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
@@ -29,9 +29,17 @@ public final class Dropdown {
           State<Integer> highlightState = ctx.useState(props::selectedIndex);
 
           boolean focused = ctx.useFocus(props.focusId(), props.autoFocus());
+          boolean open = openState.get();
 
-          // Trigger key handlers.
-          if (focused && !openState.get()) {
+          // Auto-close when focus moves elsewhere — Tab to next field, programmatic focus
+          // change, etc. The backdrop closes on outside click; this catches every other path.
+          if (open && !focused) {
+            openState.set(false);
+            open = false;
+          }
+
+          // Trigger key handlers (focused + closed → Enter/Space/Down opens).
+          if (focused && !open) {
             Runnable openIt =
                 () -> {
                   highlightState.set(props.selectedIndex());
@@ -42,12 +50,44 @@ public final class Dropdown {
             ctx.onKey(new KeyCode.Down(), openIt);
           }
 
-          // Trigger click handler — clicking the trigger opens it.
-          if (!openState.get()) {
+          // Trigger click — opens the dropdown AND focuses self so subsequent keys land here.
+          if (!open) {
             ctx.onClick(
                 e -> {
                   highlightState.set(props.selectedIndex());
                   openState.set(true);
+                  props.focusId().ifPresent(ctx::focus);
+                  e.stopPropagation();
+                });
+          }
+
+          // Open-list key handlers — registered on the DROPDOWN'S fiber (not on the overlay's
+          // portal subtree) so they sit in the focused bubble chain and actually fire.
+          if (focused && open) {
+            int hi = clamp(highlightState.get(), 0, Math.max(0, props.items().size() - 1));
+            ctx.onKey(
+                new KeyCode.Up(),
+                e -> {
+                  highlightState.set(Math.max(0, hi - 1));
+                  e.stopPropagation();
+                });
+            ctx.onKey(
+                new KeyCode.Down(),
+                e -> {
+                  highlightState.set(Math.min(props.items().size() - 1, hi + 1));
+                  e.stopPropagation();
+                });
+            ctx.onKey(
+                new KeyCode.Enter(),
+                e -> {
+                  props.onChange().accept(hi);
+                  openState.set(false);
+                  e.stopPropagation();
+                });
+            ctx.onKey(
+                new KeyCode.Esc(),
+                e -> {
+                  openState.set(false);
                   e.stopPropagation();
                 });
           }
@@ -60,17 +100,13 @@ public final class Dropdown {
           String triggerText = "  " + props.label() + ": " + selected + "  v";
           Style triggerStyle = focused ? props.focusedStyle() : props.style();
 
-          Element trigger =
-              box(
-                  "",
-                  Borders.ALL,
-                  text(triggerText, triggerStyle));
+          Element trigger = box("", Borders.ALL, text(triggerText, triggerStyle));
 
-          if (!openState.get()) {
+          if (!open) {
             return trigger;
           }
 
-          // Open: also render an overlay. Anchor to this fiber's area.
+          // Open: render the option list as a portal anchored just below the trigger.
           Rect screen = ctx.frame().area();
           Rect anchor = ctx.area().orElse(screen);
           Rect listArea = listAreaBelow(anchor, props.items().size(), screen);
@@ -80,33 +116,10 @@ public final class Dropdown {
           Element overlay =
               component(
                   c -> {
-                    c.onClick(e -> e.stopPropagation()); // eat clicks on the list itself
-                    c.onKey(
-                        new KeyCode.Up(),
-                        e -> {
-                          highlightState.set(Math.max(0, hi - 1));
-                          e.stopPropagation();
-                        });
-                    c.onKey(
-                        new KeyCode.Down(),
-                        e -> {
-                          highlightState.set(Math.min(props.items().size() - 1, hi + 1));
-                          e.stopPropagation();
-                        });
-                    c.onKey(
-                        new KeyCode.Enter(),
-                        e -> {
-                          props.onChange().accept(hi);
-                          openState.set(false);
-                          e.stopPropagation();
-                        });
-                    c.onKey(
-                        new KeyCode.Esc(),
-                        e -> {
-                          openState.set(false);
-                          e.stopPropagation();
-                        });
-                    return optionsList(props.items(), hi);
+                    // Eat clicks on the list background (gaps between rows). Per-row clicks are
+                    // attached to each row inside optionsList.
+                    c.onClick(e -> e.stopPropagation());
+                    return optionsList(props.items(), hi, props.onChange(), openState);
                   });
 
           Element backdrop =
@@ -124,7 +137,11 @@ public final class Dropdown {
         });
   }
 
-  private static Element optionsList(List<String> items, int highlightedIndex) {
+  private static Element optionsList(
+      List<String> items,
+      int highlightedIndex,
+      java.util.function.IntConsumer onChange,
+      State<Boolean> openState) {
     List<Element> rows = new ArrayList<>(items.size());
     for (int i = 0; i < items.size(); i++) {
       String item = items.get(i);
@@ -134,7 +151,19 @@ public final class Dropdown {
               ? Style.empty().withBg(new Color.Blue()).withFg(new Color.White()).withAddModifier(Modifier.BOLD)
               : Style.empty();
       String prefix = hi ? "> " : "  ";
-      rows.add(length(1, text(prefix + item, rowStyle)));
+      int idx = i;
+      Element row =
+          component(
+              c -> {
+                c.onClick(
+                    e -> {
+                      onChange.accept(idx);
+                      openState.set(false);
+                      e.stopPropagation();
+                    });
+                return text(prefix + item, rowStyle);
+              });
+      rows.add(length(1, row));
     }
     return box("", Borders.ALL, column(rows.toArray(new Element[0])));
   }

--- a/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
@@ -22,7 +22,7 @@ import tui.crossterm.KeyCode;
 public final class Dropdown {
   private Dropdown() {}
 
-  public static Element of(DropdownProps props) {
+  public static <T> Element of(DropdownProps<T> props) {
     return component(
         ctx -> {
           State<Boolean> openState = ctx.useState(() -> false);
@@ -101,11 +101,11 @@ public final class Dropdown {
           }
 
           // Build the trigger element + maybe an open-overlay.
-          String selected =
+          String selectedLabel =
               (props.selectedIndex() >= 0 && props.selectedIndex() < props.items().size())
-                  ? props.items().get(props.selectedIndex())
+                  ? props.labelFn().apply(props.items().get(props.selectedIndex()))
                   : "";
-          String triggerText = "  " + props.label() + ": " + selected + "  v";
+          String triggerText = "  " + props.label() + ": " + selectedLabel + "  v";
           Style triggerStyle = focused ? props.focusedStyle() : props.style();
 
           Element trigger = box("", Borders.ALL, text(triggerText, triggerStyle));
@@ -131,7 +131,7 @@ public final class Dropdown {
                     // this, underlying widgets' borders / text bleed through gaps in our rows.
                     return stack(
                         widget(jatatui.widgets.Clear.instance()),
-                        optionsList(props.items(), hi, props.onChange(), openState));
+                        optionsList(props.items(), props.labelFn(), hi, props.onChange(), openState));
                   });
 
           Element backdrop =
@@ -149,14 +149,16 @@ public final class Dropdown {
         });
   }
 
-  private static Element optionsList(
-      List<String> items,
+  private static <T> Element optionsList(
+      List<T> items,
+      java.util.function.Function<T, String> labelFn,
       int highlightedIndex,
       java.util.function.IntConsumer onChange,
       State<Boolean> openState) {
     List<Element> rows = new ArrayList<>(items.size());
     for (int i = 0; i < items.size(); i++) {
-      String item = items.get(i);
+      T item = items.get(i);
+      String label = labelFn.apply(item);
       boolean hi = i == highlightedIndex;
       Style rowStyle =
           hi
@@ -173,7 +175,7 @@ public final class Dropdown {
                       openState.set(false);
                       e.stopPropagation();
                     });
-                return text(prefix + item, rowStyle);
+                return text(prefix + label, rowStyle);
               });
       rows.add(length(1, row));
     }

--- a/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
@@ -119,7 +119,11 @@ public final class Dropdown {
                     // Eat clicks on the list background (gaps between rows). Per-row clicks are
                     // attached to each row inside optionsList.
                     c.onClick(e -> e.stopPropagation());
-                    return optionsList(props.items(), hi, props.onChange(), openState);
+                    // Stack Clear under the option list so the overlay is opaque — without
+                    // this, underlying widgets' borders / text bleed through gaps in our rows.
+                    return stack(
+                        widget(jatatui.widgets.Clear.instance()),
+                        optionsList(props.items(), hi, props.onChange(), openState));
                   });
 
           Element backdrop =

--- a/jatatui-components/src/java/jatatui/components/dropdown/DropdownProps.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/DropdownProps.java
@@ -3,13 +3,23 @@ package jatatui.components.dropdown;
 import jatatui.core.style.Style;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.IntConsumer;
 
-/// Props for [Dropdown]. The component is **controlled** by `selectedIndex` / `onChange`; the
+/// Props for [Dropdown].
+///
+/// Generic over the option type `T`. Each option is rendered as a label string produced by
+/// [#labelFn] — so callers can model options as records, enums, domain types, etc., without
+/// stringly-typing the wire format. The String quick-paths on [jatatui.components.Components]
+/// cover the common `List<String>` case.
+///
+/// Selection is **controlled** via [#selectedIndex] / [#onChange] (index-based, matching
+/// [jatatui.components.list.ListProps] and [jatatui.components.table.TableProps]). The
 /// open/closed state is internal.
-public record DropdownProps(
+public record DropdownProps<T>(
     String label,
-    List<String> items,
+    List<T> items,
+    Function<T, String> labelFn,
     int selectedIndex,
     IntConsumer onChange,
     Optional<String> focusId,
@@ -17,24 +27,60 @@ public record DropdownProps(
     Style style,
     Style focusedStyle) {
 
-  public static DropdownProps of(String label, List<String> items, int selectedIndex, IntConsumer onChange) {
-    return new DropdownProps(
-        label, items, selectedIndex, onChange, Optional.empty(), false, Style.empty(), Style.empty());
+  public DropdownProps {
+    items = List.copyOf(items);
   }
 
-  public DropdownProps withFocusId(String focusId) {
-    return new DropdownProps(label, items, selectedIndex, onChange, Optional.of(focusId), autoFocus, style, focusedStyle);
+  /// Generic factory.
+  public static <T> DropdownProps<T> of(
+      String label,
+      List<T> items,
+      Function<T, String> labelFn,
+      int selectedIndex,
+      IntConsumer onChange) {
+    return new DropdownProps<>(
+        label,
+        items,
+        labelFn,
+        selectedIndex,
+        onChange,
+        Optional.empty(),
+        false,
+        Style.empty(),
+        Style.empty());
   }
 
-  public DropdownProps withAutoFocus(boolean autoFocus) {
-    return new DropdownProps(label, items, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
+  /// Quick-path for `List<String>` — labelFn = identity.
+  public static DropdownProps<String> ofStrings(
+      String label, List<String> items, int selectedIndex, IntConsumer onChange) {
+    return of(label, items, Function.identity(), selectedIndex, onChange);
   }
 
-  public DropdownProps withStyle(Style style) {
-    return new DropdownProps(label, items, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
+  public DropdownProps<T> withFocusId(String focusId) {
+    return new DropdownProps<>(
+        label,
+        items,
+        labelFn,
+        selectedIndex,
+        onChange,
+        Optional.of(focusId),
+        autoFocus,
+        style,
+        focusedStyle);
   }
 
-  public DropdownProps withFocusedStyle(Style focusedStyle) {
-    return new DropdownProps(label, items, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
+  public DropdownProps<T> withAutoFocus(boolean autoFocus) {
+    return new DropdownProps<>(
+        label, items, labelFn, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
+  }
+
+  public DropdownProps<T> withStyle(Style style) {
+    return new DropdownProps<>(
+        label, items, labelFn, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
+  }
+
+  public DropdownProps<T> withFocusedStyle(Style focusedStyle) {
+    return new DropdownProps<>(
+        label, items, labelFn, selectedIndex, onChange, focusId, autoFocus, style, focusedStyle);
   }
 }

--- a/jatatui-components/src/java/jatatui/components/link/Link.java
+++ b/jatatui-components/src/java/jatatui/components/link/Link.java
@@ -1,0 +1,59 @@
+package jatatui.components.link;
+
+import static jatatui.react.Components.*;
+
+import jatatui.react.Element;
+import java.util.Optional;
+import java.util.function.Function;
+import tui.crossterm.KeyCode;
+
+/// Hyperlink-style focusable + clickable activation target. Wraps a body Element with a
+/// `useFocus` / `onKey(Enter)` / `onClick` triad so each link doesn't reimplement the same
+/// three lines. The body is a function of the live focus state so the caller can paint the
+/// focused/unfocused variant without re-querying.
+///
+/// Router-agnostic: takes a [Runnable] `onActivate`. The most common use is
+/// `() -> router.push(screen)` (matches the typr.cli.app.components.Link original), but any
+/// callback works (open a modal, open a URL, etc.).
+public final class Link {
+  private Link() {}
+
+  /// Tab-focusable link. Activation = Enter when focused OR mouse click anywhere in the body's
+  /// area. `content(focused)` receives the live focus state.
+  public static Element focusable(
+      boolean autoFocus, Runnable onActivate, Function<Boolean, Element> content) {
+    return component(
+        ctx -> {
+          boolean focused = ctx.useFocus(Optional.empty(), autoFocus);
+          if (focused) ctx.onKey(new KeyCode.Enter(), onActivate);
+          ctx.onClick(e -> onActivate.run());
+          return content.apply(focused);
+        });
+  }
+
+  /// Tab-focusable link with an explicit focus id (for imperative `ctx.focus(id)` / Tab order
+  /// stability across reorders).
+  public static Element focusable(
+      String focusId,
+      boolean autoFocus,
+      Runnable onActivate,
+      Function<Boolean, Element> content) {
+    return component(
+        ctx -> {
+          boolean focused = ctx.useFocus(Optional.of(focusId), autoFocus);
+          if (focused) ctx.onKey(new KeyCode.Enter(), onActivate);
+          ctx.onClick(e -> onActivate.run());
+          return content.apply(focused);
+        });
+  }
+
+  /// Bare click-to-activate. NOT focusable — activate by mouse only. Useful for icons / chips
+  /// where a Tab stop would be intrusive.
+  public static Element click(Runnable onActivate, Element content) {
+    return component(
+        ctx -> {
+          ctx.onClick(e -> onActivate.run());
+          return content;
+        });
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/modal/ConfirmDialog.java
+++ b/jatatui-components/src/java/jatatui/components/modal/ConfirmDialog.java
@@ -1,0 +1,65 @@
+package jatatui.components.modal;
+
+import static jatatui.react.Components.*;
+
+import jatatui.components.button.Button;
+import jatatui.core.layout.Size;
+import jatatui.core.style.Color;
+import jatatui.core.style.Modifier;
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+
+/// Yes/No confirmation modal for destructive or commit actions. Built on [Modal]; the host
+/// owns the open/closed state (typically a `useState<Optional<...>>` whose presence drives
+/// `open`).
+///
+/// `danger=true` paints the box border red and gives the confirm button its primary-green
+/// styling overridden to red — used for delete / drop / wipe. `danger=false` gives a neutral
+/// cyan box (e.g. "apply changes?").
+///
+/// Layout: title bar (modal chrome), message, two side-by-side buttons (`confirm` primary,
+/// `cancel` secondary), hint line at the bottom.
+public final class ConfirmDialog {
+  private ConfirmDialog() {}
+
+  public static final Size DEFAULT_SIZE = new Size(60, 11);
+
+  public static Element of(
+      boolean open,
+      String title,
+      String message,
+      String confirmLabel,
+      String cancelLabel,
+      boolean danger,
+      Runnable onConfirm,
+      Runnable onCancel) {
+    Element body =
+        column(
+            length(1, empty()),
+            length(1, text("  " + message, Style.empty().withFg(new Color.White()))),
+            length(1, empty()),
+            length(
+                3,
+                row(
+                    fill(1, empty()),
+                    length(16, Button.of(confirmLabel, "confirm-yes", true, onConfirm)),
+                    length(2, empty()),
+                    length(14, Button.of(cancelLabel, "confirm-no", false, onCancel)),
+                    fill(1, empty()))),
+            fill(1, empty()),
+            length(
+                1,
+                text(
+                    "  enter confirm · esc cancel",
+                    Style.empty().withFg(new Color.DarkGray()))));
+
+    Style boxStyle =
+        Style.empty()
+            .withFg(danger ? new Color.Red() : new Color.Cyan())
+            .withAddModifier(Modifier.BOLD);
+    return Modal.of(
+        ModalProps.of(open, title, body, onCancel)
+            .withSize(DEFAULT_SIZE)
+            .withBoxStyle(boxStyle));
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/modal/Modal.java
+++ b/jatatui-components/src/java/jatatui/components/modal/Modal.java
@@ -27,7 +27,7 @@ public final class Modal {
     return component(
         ctx -> {
           Rect screen = ctx.frame().area();
-          Rect boxArea = centerInside(screen, props.width(), props.height());
+          Rect boxArea = centerInside(screen, props.size().width(), props.size().height());
 
           Element backdrop =
               component(

--- a/jatatui-components/src/java/jatatui/components/modal/ModalProps.java
+++ b/jatatui-components/src/java/jatatui/components/modal/ModalProps.java
@@ -1,37 +1,44 @@
 package jatatui.components.modal;
 
+import jatatui.core.layout.Size;
 import jatatui.core.style.Style;
 import jatatui.react.Element;
 import java.util.Optional;
 
-/// Props for [Modal]. `width` / `height` are absolute cell counts; the modal centers itself on
-/// the screen. If the screen is smaller than the requested size, the modal shrinks to fit.
+/// Props for [Modal]. [#size] is the requested cell-count; the modal centers itself on the
+/// screen, shrinking to fit if the screen is smaller than the requested size.
 public record ModalProps(
     boolean open,
     String title,
     Element body,
     Runnable onDismiss,
-    int width,
-    int height,
+    Size size,
     Optional<Style> backdropStyle,
     Style boxStyle) {
 
-  /// Default-styled factory: 40 wide × 12 tall. No backdrop dimming. Esc / click-outside dismiss.
+  public static final Size DEFAULT_SIZE = new Size(40, 12);
+
+  /// Default-styled factory: 40×12 modal, no backdrop dimming, Esc / click-outside dismiss.
   public static ModalProps of(boolean open, String title, Element body, Runnable onDismiss) {
     return new ModalProps(
-        open, title, body, onDismiss, 40, 12, Optional.empty(), Style.empty());
+        open, title, body, onDismiss, DEFAULT_SIZE, Optional.empty(), Style.empty());
   }
 
+  public ModalProps withSize(Size size) {
+    return new ModalProps(open, title, body, onDismiss, size, backdropStyle, boxStyle);
+  }
+
+  /// Quick-path that takes width / height as cell counts.
   public ModalProps withSize(int width, int height) {
-    return new ModalProps(open, title, body, onDismiss, width, height, backdropStyle, boxStyle);
+    return withSize(new Size(width, height));
   }
 
   public ModalProps withBackdropStyle(Style backdropStyle) {
     return new ModalProps(
-        open, title, body, onDismiss, width, height, Optional.of(backdropStyle), boxStyle);
+        open, title, body, onDismiss, size, Optional.of(backdropStyle), boxStyle);
   }
 
   public ModalProps withBoxStyle(Style boxStyle) {
-    return new ModalProps(open, title, body, onDismiss, width, height, backdropStyle, boxStyle);
+    return new ModalProps(open, title, body, onDismiss, size, backdropStyle, boxStyle);
   }
 }

--- a/jatatui-components/src/java/jatatui/components/picker/Picker.java
+++ b/jatatui-components/src/java/jatatui/components/picker/Picker.java
@@ -1,0 +1,173 @@
+package jatatui.components.picker;
+
+import static jatatui.react.Components.*;
+
+import jatatui.components.textinput.TextInputComponent;
+import jatatui.components.textinput.TextInputProps;
+import jatatui.core.layout.Rect;
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.State;
+import jatatui.widgets.Borders;
+import java.util.List;
+import tui.crossterm.KeyCode;
+
+/// Search-input + ranked-list modal. The host opens this conditionally (when a search hotkey
+/// fires) and drives the result list via [PickerProps.Filter]; this component owns the query
+/// state, the selection cursor, and the modal chrome.
+///
+/// Triggers:
+///   - **Text input**: prints into the query field; results re-rank on each keystroke (caller's
+///     filter is invoked, so it sees `"c"`, then `"cu"`, …).
+///   - **Up/Down**: move the highlight. Bubble-phase + stopPropagation, so a wrapping screen's
+///     own arrow handlers don't fire while the picker is open.
+///   - **Enter**: commits `onSelect(highlighted)`; doesn't auto-close (host decides).
+///   - **Esc**: invokes `onCancel`.
+///   - **Click on a row**: commits that row.
+///   - **Click outside the modal**: invokes `onCancel`.
+///
+/// The picker doesn't have a single source of truth for "is the picker open" — render it
+/// conditionally on the host side. The picker only deals with what to show while it IS
+/// visible. This matches [jatatui.components.modal.Modal]'s approach.
+public final class Picker {
+  private Picker() {}
+
+  public static <T> Element of(PickerProps<T> props) {
+    return component(
+        ctx -> {
+          State<String> query       = ctx.useState(() -> "");
+          State<Integer> selectedIdx = ctx.useState(() -> 0);
+
+          List<T> results = props.filter().apply(query.get());
+          int cap         = Math.min(props.maxVisible(), results.size());
+          List<T> capped  = results.subList(0, cap);
+
+          int sel = capped.isEmpty() ? 0 : Math.max(0, Math.min(selectedIdx.get(), capped.size() - 1));
+
+          ctx.onKey(
+              new KeyCode.Esc(),
+              (KeyEvent e) -> {
+                props.onCancel().run();
+                e.stopPropagation();
+              });
+          ctx.onKey(
+              new KeyCode.Up(),
+              (KeyEvent e) -> {
+                if (!capped.isEmpty()) selectedIdx.set(Math.max(0, sel - 1));
+                e.stopPropagation();
+              });
+          ctx.onKey(
+              new KeyCode.Down(),
+              (KeyEvent e) -> {
+                if (!capped.isEmpty()) selectedIdx.set(Math.min(capped.size() - 1, sel + 1));
+                e.stopPropagation();
+              });
+          ctx.onKey(
+              new KeyCode.Enter(),
+              (KeyEvent e) -> {
+                if (!capped.isEmpty()) props.onSelect().accept(capped.get(sel));
+                e.stopPropagation();
+              });
+
+          Element input =
+              length(
+                  3,
+                  TextInputComponent.of(
+                      TextInputProps.of(
+                              query.get(),
+                              v -> {
+                                query.set(v);
+                                selectedIdx.set(0); // reset cursor when the query changes
+                              })
+                          .withTitle("")
+                          .withFocusId("picker:query")
+                          .withAutoFocus(true)));
+
+          Element resultsPane = capped.isEmpty()
+              ? fill(1, text("  no matches", Style.empty().withFg(new jatatui.core.style.Color.DarkGray())))
+              : fill(1, resultRows(props, capped, sel));
+
+          Element modalBody;
+          if (props.hint().isPresent()) {
+            modalBody =
+                stack(
+                    widget(jatatui.widgets.Clear.instance()),
+                    box(
+                        props.title(),
+                        Borders.ALL,
+                        input,
+                        resultsPane,
+                        length(
+                            1,
+                            text(
+                                props.hint().get(),
+                                Style.empty().withFg(new jatatui.core.style.Color.DarkGray())))));
+          } else {
+            modalBody =
+                stack(
+                    widget(jatatui.widgets.Clear.instance()),
+                    box(props.title(), Borders.ALL, input, resultsPane));
+          }
+
+          // Two portals layered on screen: backdrop for outside-click cancellation, then the
+          // modal box itself. Same pattern as Modal.
+          Rect screen = ctx.frame().area();
+          Rect modalArea = centerInside(screen, props.size().width(), props.size().height());
+
+          Element backdrop =
+              component(
+                  c -> {
+                    c.onClick(
+                        e -> {
+                          props.onCancel().run();
+                          e.stopPropagation();
+                        });
+                    return empty();
+                  });
+
+          // Eat clicks on the box so they don't bubble to the backdrop.
+          Element boxLayer =
+              component(
+                  c -> {
+                    c.onClick(e -> e.stopPropagation());
+                    return modalBody;
+                  });
+
+          return column(portal(backdrop, screen), portal(boxLayer, modalArea));
+        });
+  }
+
+  /// One clickable row per result. Click → `onSelect` for that row; the picker does NOT close
+  /// itself (host's call).
+  private static <T> Element resultRows(PickerProps<T> props, List<T> items, int selectedIdx) {
+    Element[] rows = new Element[items.size()];
+    for (int i = 0; i < items.size(); i++) {
+      final int idx = i;
+      final T item  = items.get(i);
+      final boolean selected = idx == selectedIdx;
+      rows[i] =
+          length(
+              1,
+              component(
+                  c -> {
+                    c.onClick(
+                        (MouseEvent e) -> {
+                          props.onSelect().accept(item);
+                          e.stopPropagation();
+                        });
+                    return props.rowRenderer().render(item, selected);
+                  }));
+    }
+    return column(rows);
+  }
+
+  private static Rect centerInside(Rect outer, int width, int height) {
+    int w = Math.min(width, outer.width());
+    int h = Math.min(height, outer.height());
+    int x = outer.x() + (outer.width() - w) / 2;
+    int y = outer.y() + (outer.height() - h) / 2;
+    return new Rect(x, y, w, h);
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/picker/Picker.java
+++ b/jatatui-components/src/java/jatatui/components/picker/Picker.java
@@ -34,11 +34,23 @@ import tui.crossterm.KeyCode;
 public final class Picker {
   private Picker() {}
 
+  /// Focus id for the internal text input. Stable across renders so that a host that wants to
+  /// imperatively focus or blur the picker's input can target it directly.
+  public static final String QUERY_FOCUS_ID = "picker:query";
+
   public static <T> Element of(PickerProps<T> props) {
     return component(
         ctx -> {
           State<String> query       = ctx.useState(() -> "");
           State<Integer> selectedIdx = ctx.useState(() -> 0);
+
+          // Forcibly claim focus for the query field on mount. The text input registers with
+          // autoFocus=true, but FocusManager's eager-claim only fires when nothing else is
+          // focused — if the host has another autoFocus'd element rendered first (e.g. a list
+          // underneath the modal), the input never gets focus and keystrokes leak to host
+          // handlers. useEffect with empty deps runs once per mount (and again after any
+          // unmount/remount — reconciliation handles both).
+          ctx.useEffect(() -> ctx.focus(QUERY_FOCUS_ID));
 
           List<T> results = props.filter().apply(query.get());
           int cap         = Math.min(props.maxVisible(), results.size());
@@ -82,7 +94,7 @@ public final class Picker {
                                 selectedIdx.set(0); // reset cursor when the query changes
                               })
                           .withTitle("")
-                          .withFocusId("picker:query")
+                          .withFocusId(QUERY_FOCUS_ID)
                           .withAutoFocus(true)));
 
           Element resultsPane = capped.isEmpty()

--- a/jatatui-components/src/java/jatatui/components/picker/PickerProps.java
+++ b/jatatui-components/src/java/jatatui/components/picker/PickerProps.java
@@ -1,0 +1,100 @@
+package jatatui.components.picker;
+
+import jatatui.core.layout.Size;
+import jatatui.react.Element;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/// Props for [Picker].
+///
+/// A search-input + ranked-list modal — VSCode's "Quick Pick", IntelliJ's "Go To Symbol",
+/// Sublime's "Go to Anything". Text input at top, results below, Up/Down navigates, Enter
+/// commits, Esc cancels, click commits.
+///
+/// **Type parameter `T` is the item type** — it threads through [Filter], [RowRenderer],
+/// and `onSelect`, so the compiler enforces that you render and act on the same kind of value
+/// you filter for.
+///
+/// [Filter] is the filter/rank strategy. Given the live query string, return the items to show
+/// in order of relevance. Callers plug in whatever scorer fits (substring, regex,
+/// IntelliJ-style fuzzy, domain-specific). Empty-query behaviour is the caller's call too:
+/// return all items, or an empty list ("type to search"), or recent-history items.
+///
+/// [RowRenderer] is how each result row paints itself. It receives the selection state so the
+/// row can highlight when chosen. The Picker never imposes its own row styling.
+///
+/// `onSelect` fires when the user commits (Enter on the highlighted row, or click). The Picker
+/// does NOT close itself — the host decides whether to hide it (typical) or keep it open for
+/// multi-select. Same for `onCancel` (Esc or backdrop click).
+///
+/// `hint` is the bottom hint line. The default ("up/down navigate · enter select · esc cancel")
+/// is shown via [#of]; pass [Optional#empty] to drop the line, or any string to localize.
+public record PickerProps<T>(
+    String title,
+    Filter<T> filter,
+    RowRenderer<T> rowRenderer,
+    Consumer<T> onSelect,
+    Runnable onCancel,
+    Size size,
+    int maxVisible,
+    Optional<String> hint) {
+
+  /// Minimal-args factory: title, filter, rowRenderer, onSelect, onCancel. Defaults to an
+  /// 80×20 modal, 100 visible rows, English hint line.
+  public static <T> PickerProps<T> of(
+      String title,
+      Filter<T> filter,
+      RowRenderer<T> rowRenderer,
+      Consumer<T> onSelect,
+      Runnable onCancel) {
+    return new PickerProps<>(
+        title,
+        filter,
+        rowRenderer,
+        onSelect,
+        onCancel,
+        new Size(80, 20),
+        100,
+        Optional.of("  up/down navigate · enter select · esc cancel"));
+  }
+
+  public PickerProps<T> withSize(Size size) {
+    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+  }
+
+  /// Cap on the number of rows rendered. Beyond ~100 the user re-types instead of scrolling;
+  /// rendering more just costs frames.
+  public PickerProps<T> withMaxVisible(int maxVisible) {
+    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+  }
+
+  /// Replace the bottom hint line. Pass [Optional#empty] to drop it entirely.
+  public PickerProps<T> withHint(Optional<String> hint) {
+    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+  }
+
+  public PickerProps<T> withHint(String hint) {
+    return withHint(Optional.of(hint));
+  }
+
+  public PickerProps<T> withoutHint() {
+    return withHint(Optional.empty());
+  }
+
+  // ---- Type-safe lambda surrogates ----
+
+  /// Given the current query, produce the items to display. Order matters — first comes first.
+  /// Empty query semantics is the caller's call.
+  @FunctionalInterface
+  public interface Filter<T> {
+    List<T> apply(String query);
+  }
+
+  /// Paint one result row. `selected=true` when this row is highlighted; the renderer chooses
+  /// how to indicate selection (bg colour, caret, bold, etc.).
+  @FunctionalInterface
+  public interface RowRenderer<T> {
+    Element render(T item, boolean selected);
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/router/Router.java
+++ b/jatatui-components/src/java/jatatui/components/router/Router.java
@@ -10,6 +10,13 @@ import java.util.List;
 
 /// Mount near the app root with a base [Screen]. Provides a [RouterApi] via Context. Renders the
 /// current top-of-stack screen.
+///
+/// **Focus contract:** every stack transition (`push` / `pop` / `replace` / `reset`) clears
+/// focus before the new top-of-stack renders, so the new screen's `useFocus(autoFocus=true)`
+/// claims same-frame via the eager-claim path. Without this, `focused` would still point at the
+/// outgoing screen's id, the new screen's first frame would paint as nothing-focused, and
+/// commit's post-frame re-pick would only become visible on the second frame (a perceptible
+/// one-frame flicker).
 public final class Router {
   private Router() {}
 
@@ -33,6 +40,7 @@ public final class Router {
 
                 @Override
                 public void push(Screen screen) {
+                  ctx.blur();
                   stackState.update(
                       prev -> {
                         List<Screen> next = new ArrayList<>(prev);
@@ -43,6 +51,7 @@ public final class Router {
 
                 @Override
                 public void pop() {
+                  ctx.blur();
                   stackState.update(
                       prev -> {
                         if (prev.size() <= 1) return prev;
@@ -52,6 +61,7 @@ public final class Router {
 
                 @Override
                 public void replace(Screen screen) {
+                  ctx.blur();
                   stackState.update(
                       prev -> {
                         List<Screen> next = new ArrayList<>(prev);
@@ -62,6 +72,7 @@ public final class Router {
 
                 @Override
                 public void reset() {
+                  ctx.blur();
                   stackState.set(List.of(base));
                 }
 

--- a/jatatui-components/src/java/jatatui/components/scrollable/Scrollable.java
+++ b/jatatui-components/src/java/jatatui/components/scrollable/Scrollable.java
@@ -1,0 +1,52 @@
+package jatatui.components.scrollable;
+
+import static jatatui.react.Components.*;
+
+import jatatui.core.layout.Rect;
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.State;
+import java.util.List;
+
+/// Wrap a list of fixed-height children so the mouse wheel scrolls them. Three rows per wheel
+/// tick. Max offset is clamped against the assigned area's height — wheel-down stops at the
+/// point where the last child is exactly aligned to the bottom of the visible window, so you
+/// can't over-scroll past the content (the typr.cli.app.components.Scrollable original noted
+/// this as a TODO; we do the right thing here).
+///
+/// Focus is intentionally NOT adjusted on scroll — Tab order stays consistent with render
+/// order, so a scrolled-out focused item is still reachable via keyboard. Click-to-focus on a
+/// visible child works as usual.
+///
+/// For lists of selectable items where Up/Down should move the selection and the viewport
+/// should follow, use [jatatui.components.selectablelist.SelectableList] instead — it owns
+/// the selection logic and auto-scrolls when the cursor leaves the viewport.
+public final class Scrollable {
+  private Scrollable() {}
+
+  /// Cells scrolled per wheel tick.
+  public static final int STEP = 3;
+
+  public static Element column(List<Element> children) {
+    return component(
+        ctx -> {
+          State<Integer> offset = ctx.useState(() -> 0);
+          int areaHeight = ctx.area().map(Rect::height).orElse(children.size());
+          int maxOffset = Math.max(0, children.size() - Math.max(1, areaHeight));
+
+          int liveOffset = Math.min(offset.get(), maxOffset);
+          ctx.onScroll(
+              (MouseEvent e) -> {
+                switch (e.kind()) {
+                  case SCROLL_UP -> offset.set(Math.max(0, liveOffset - STEP));
+                  case SCROLL_DOWN -> offset.set(Math.min(maxOffset, liveOffset + STEP));
+                  default -> {}
+                }
+              });
+
+          List<Element> visible = children.subList(liveOffset, children.size());
+          if (visible.isEmpty()) return empty();
+          return jatatui.react.Components.column(visible.toArray(new Element[0]));
+        });
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/search/FuzzyMatch.java
+++ b/jatatui-components/src/java/jatatui/components/search/FuzzyMatch.java
@@ -1,0 +1,115 @@
+package jatatui.components.search;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/// IntelliJ-style fuzzy matching: each char of `query` must appear in `target` in order (a
+/// subsequence), and matches on a word boundary score much higher than mid-word matches.
+///
+/// **Word boundary** covers:
+///   - first char of the string
+///   - first char after a separator (`_`, `.`, `-`, `/`, space)
+///   - an uppercase letter following a lowercase one (camelCase)
+///   - a digit following a letter (or vice versa)
+///
+/// Examples:
+///   - `"cn"` matches `"customer_name"` and `"customerName"` (word-start hits each side)
+///   - `"sc"` matches `"sales.customer"` (s and c word starts)
+///   - `"cust"` matches `"customer"` (one word-start + three intra-word chars)
+///
+/// Case-insensitive. Returns [Optional#empty] when no subsequence is possible; otherwise a
+/// score where larger = better.
+///
+/// Plugs directly into [jatatui.components.picker.PickerProps.Filter]: build an [Indexed] list
+/// once when the corpus is known, then call [#rank] per keystroke.
+public final class FuzzyMatch {
+  private FuzzyMatch() {}
+
+  private static final int WORD_START_BONUS = 10;
+  private static final int IN_WORD_BONUS = 1;
+
+  /// Indices of word starts in `s` per the rules above.
+  public static Set<Integer> wordStarts(String s) {
+    Set<Integer> out = new HashSet<>();
+    int n = s.length();
+    for (int i = 0; i < n; i++) {
+      char c = s.charAt(i);
+      if (!Character.isLetterOrDigit(c)) continue;
+      boolean isStart;
+      if (i == 0) {
+        isStart = true;
+      } else {
+        char prev = s.charAt(i - 1);
+        boolean prevSep = !Character.isLetterOrDigit(prev);
+        boolean camel = Character.isUpperCase(c) && Character.isLowerCase(prev);
+        boolean ld =
+            (Character.isDigit(c) && Character.isLetter(prev))
+                || (Character.isLetter(c) && Character.isDigit(prev));
+        isStart = prevSep || camel || ld;
+      }
+      if (isStart) out.add(i);
+    }
+    return out;
+  }
+
+  /// Convenience entry point — computes [#wordStarts] on the fly. Use [#scoreWith] when the
+  /// same target gets scored many times (search-as-you-type).
+  public static Optional<Integer> score(String query, String target) {
+    return scoreWith(query, target, target.toLowerCase(), wordStarts(target));
+  }
+
+  /// Hot-path scorer: caller supplies the precomputed lowercase target + word starts. Empty
+  /// query returns a tiny negative score proportional to target length, so short items sort
+  /// first when no query has been typed.
+  public static Optional<Integer> scoreWith(
+      String query, String target, String targetLower, Set<Integer> ws) {
+    if (query.isEmpty()) return Optional.of(-target.length());
+    String q = query.toLowerCase();
+    int tn = targetLower.length();
+    int qn = q.length();
+
+    int qi = 0;
+    int ti = 0;
+    int s = 0;
+    while (ti < tn && qi < qn) {
+      if (targetLower.charAt(ti) == q.charAt(qi)) {
+        s += ws.contains(ti) ? WORD_START_BONUS : IN_WORD_BONUS;
+        qi++;
+      }
+      ti++;
+    }
+    if (qi == qn) return Optional.of(s - target.length() / 4);
+    return Optional.empty();
+  }
+
+  /// Pre-indexed item: payload + precomputed label / labelLower / wordStarts. Build the list
+  /// once when the corpus is known; reuse across every keystroke.
+  public record Indexed<A>(A item, String label, String labelLower, Set<Integer> wordStarts) {}
+
+  public static <A> List<Indexed<A>> index(List<A> items, Function<A, String> label) {
+    return items.stream()
+        .map(
+            a -> {
+              String l = label.apply(a);
+              return new Indexed<>(a, l, l.toLowerCase(), wordStarts(l));
+            })
+        .toList();
+  }
+
+  /// Filter + rank pre-indexed items. Empty query returns every item in original order.
+  public static <A> List<A> rank(String query, List<Indexed<A>> indexed) {
+    if (query.isEmpty()) return indexed.stream().map(Indexed::item).toList();
+    record Scored<A>(A item, int score) {}
+    return indexed.stream()
+        .flatMap(
+            i ->
+                scoreWith(query, i.label(), i.labelLower(), i.wordStarts()).stream()
+                    .map(s -> new Scored<>(i.item(), s)))
+        .sorted((a, b) -> Integer.compare(b.score(), a.score()))
+        .map(Scored::item)
+        .toList();
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
@@ -136,9 +136,14 @@ public final class SelectableList {
           Element rowsColumn = column(visible.toArray(new Element[0]));
 
           // Render a vertical-right scrollbar when content overflows and the caller wants it.
-          // We use the scrollbar component layered on top via stack so it doesn't steal a column
-          // from the row renderer — rows can use the full width up to the rightmost cell, and
-          // the scrollbar overpaints that last cell when present.
+          // We reserve the rightmost column for the scrollbar via row(fill, length) rather than
+          // stacking it on top of the rows. Stacking causes a colour-bleed bug: paragraphs
+          // (`text(content, style)`) call `buf.setStyle(area, style)`, painting the row's fg
+          // onto every cell — including the rightmost. The scrollbar's thumb writes its glyph
+          // with `Style.empty()`, and `Cell.setStyle` only patches what the style has set, so
+          // the thumb inherits the row's fg. Reserving the column avoids the overpaint, and
+          // the trade-off — content reflows by 1 column when overflow toggles — matches what
+          // every GUI scrollbar does.
           //
           // Content overflows when n > visibleH; otherwise we render nothing (no scrollbar is
           // visually noise for short lists) so callers get the same behaviour as before.
@@ -147,7 +152,7 @@ public final class SelectableList {
             Element bar =
                 jatatui.components.scrollbar.Components.scrollbar(
                     offset, n, visibleH, ScrollbarOrientation.VerticalRight);
-            return stack(rowsColumn, bar);
+            return row(fill(1, rowsColumn), length(1, bar));
           }
           return rowsColumn;
         });

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
@@ -6,6 +6,7 @@ import jatatui.core.layout.Rect;
 import jatatui.react.Element;
 import jatatui.react.KeyEvent;
 import jatatui.react.MouseEvent;
+import jatatui.react.Ref;
 import jatatui.react.State;
 import jatatui.widgets.scrollbar.ScrollbarOrientation;
 import java.util.ArrayList;
@@ -40,6 +41,16 @@ public final class SelectableList {
 
   private static final int SCROLL_STEP = 3;
 
+  /// How long after a single click a click on the same row counts as a double-click. 500ms
+  /// matches the OS double-click default on macOS / Windows / GTK at their stock settings.
+  private static final long DOUBLE_CLICK_MS = 500;
+
+  /// Internal: most-recently-clicked row and its timestamp. Shared across all row components
+  /// of one list so clicking row A then row B doesn't trigger a "double-click" on B.
+  record LastClick(int row, long timeMs) {
+    static final LastClick NONE = new LastClick(-1, 0L);
+  }
+
   public static <T> Element of(SelectableListProps<T> props) {
     return component(
         ctx -> {
@@ -53,6 +64,9 @@ public final class SelectableList {
           }
 
           State<Integer> offsetState = ctx.useState(() -> 0);
+          // Shared across all row components — see LastClick. Captured into renderRow so each
+          // row's onClick can consult/update the same mutable state.
+          Ref<LastClick> lastClickRef = ctx.useRef(() -> LastClick.NONE);
           int sel = n == 0 ? 0 : Math.max(0, Math.min(props.selected(), n - 1));
 
           int areaHeight = ctx.area().map(Rect::height).orElse(20);
@@ -128,7 +142,7 @@ public final class SelectableList {
           for (int i = offset; i < upper; i++) {
             final int idx = i;
             final T item = items.get(i);
-            visible.add(length(1, renderRow(props, item, idx, sel)));
+            visible.add(length(1, renderRow(props, item, idx, sel, lastClickRef)));
           }
 
           if (visible.isEmpty()) return empty();
@@ -193,7 +207,7 @@ public final class SelectableList {
   }
 
   private static <T> Element renderRow(
-      SelectableListProps<T> props, T item, int idx, int selected) {
+      SelectableListProps<T> props, T item, int idx, int selected, Ref<LastClick> lastClickRef) {
     final boolean isSel = idx == selected;
     final boolean activatable = props.isActivatable().test(item);
     return component(
@@ -201,10 +215,27 @@ public final class SelectableList {
           if (activatable) {
             ctx.onClick(
                 (MouseEvent e) -> {
-                  if (isSel) {
-                    props.onActivate().ifPresent(cb -> cb.accept(item));
+                  if (props.activateOnDoubleClick()) {
+                    LastClick last = lastClickRef.get();
+                    long now = System.currentTimeMillis();
+                    if (idx == last.row() && (now - last.timeMs()) < DOUBLE_CLICK_MS) {
+                      // Double-click: activate. Reset the click-tracking so a third quick
+                      // click doesn't fire a second activation.
+                      props.onActivate().ifPresent(cb -> cb.accept(item));
+                      lastClickRef.set(LastClick.NONE);
+                    } else {
+                      // Single-click: select only. Note the row + time so a subsequent click
+                      // can be detected as a double-click.
+                      if (!isSel) props.onSelectChange().accept(idx);
+                      lastClickRef.set(new LastClick(idx, now));
+                    }
                   } else {
-                    props.onSelectChange().accept(idx);
+                    // Legacy: click on the already-selected row activates; else just select.
+                    if (isSel) {
+                      props.onActivate().ifPresent(cb -> cb.accept(item));
+                    } else {
+                      props.onSelectChange().accept(idx);
+                    }
                   }
                   e.stopPropagation();
                 });

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
@@ -1,0 +1,184 @@
+package jatatui.components.selectablelist;
+
+import static jatatui.react.Components.*;
+
+import jatatui.core.layout.Rect;
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.State;
+import java.util.ArrayList;
+import java.util.List;
+import tui.crossterm.KeyCode;
+
+/// Keyboard + mouse + wheel-scrollable list of arbitrary [Element] rows with selection.
+///
+/// Differs from [jatatui.components.list.ListComponent]:
+///   - rows are [Element]s, not String labels (caller supplies [SelectableListProps.RowRenderer]);
+///   - rows can be **non-activatable** (decoration: headers, dividers, totals). Up/Down skips
+///     them, Enter / Enter-on-click ignores them.
+///
+/// Selection is controlled (parent owns `selected`, child notifies via `onSelectChange`); scroll
+/// offset is internal and clamped so the selected row is always visible.
+///
+/// Triggers:
+///   - **Up / Down**: move selection to next/prev activatable row.
+///   - **Enter**: invokes `onActivate(items.get(selected))`, if `onActivate` was set AND the
+///     selected row is activatable.
+///   - **Click on an activatable row**: selects it (if not already), or activates if it's the
+///     current selection.
+///   - **Mouse wheel**: scrolls the viewport without moving selection.
+///
+/// Keyboard handlers register on this component's fiber via [bubble-phase onKey], so a wrapping
+/// screen's own arrow handlers won't double-fire while the list is focused. Wraps via
+/// `stopPropagation()`.
+public final class SelectableList {
+  private SelectableList() {}
+
+  private static final int SCROLL_STEP = 3;
+
+  public static <T> Element of(SelectableListProps<T> props) {
+    return component(
+        ctx -> {
+          List<T> items = props.items();
+          int n         = items.size();
+
+          // Indices of activatable rows — Up/Down skip everything else.
+          List<Integer> activatableIdxs = new ArrayList<>();
+          for (int i = 0; i < n; i++) {
+            if (props.isActivatable().test(items.get(i))) activatableIdxs.add(i);
+          }
+
+          State<Integer> offsetState = ctx.useState(() -> 0);
+          int sel = n == 0 ? 0 : Math.max(0, Math.min(props.selected(), n - 1));
+
+          int areaHeight = ctx.area().map(Rect::height).orElse(20);
+          int visibleH   = Math.max(1, areaHeight);
+
+          // Auto-scroll only when selection actually changed (or on first render). Without this
+          // gate, mouse-wheel scrolls would be reverted on the next render — sel hadn't moved
+          // but the auto-scroll would re-pull offset back to keep sel in view.
+          var prevSelRef = ctx.useRef(() -> -1);
+          int prevSel = prevSelRef.get();
+          prevSelRef.set(sel);
+          boolean selChanged = sel != prevSel;
+
+          int offset = offsetState.get();
+          if (selChanged) {
+            int newOffset =
+                (sel < offset) ? sel
+                    : (sel >= offset + visibleH) ? sel - visibleH + 1
+                    : offset;
+            if (newOffset != offset) {
+              offsetState.set(newOffset);
+              offset = newOffset;
+            }
+          }
+
+          // Claim focus so onKey for Up/Down/Enter fires when the user types into the list. We
+          // treat the list itself as one focusable entity rather than wiring each row into the
+          // FocusManager.
+          boolean focused = ctx.useFocus(props.focusId(), props.autoFocus());
+
+          if (focused) {
+            ctx.onKey(
+                new KeyCode.Up(),
+                (KeyEvent e) -> {
+                  Integer next = moveSelection(activatableIdxs, sel, -1);
+                  if (next != null) props.onSelectChange().accept(next);
+                  e.stopPropagation();
+                });
+            ctx.onKey(
+                new KeyCode.Down(),
+                (KeyEvent e) -> {
+                  Integer next = moveSelection(activatableIdxs, sel, +1);
+                  if (next != null) props.onSelectChange().accept(next);
+                  e.stopPropagation();
+                });
+            props
+                .onActivate()
+                .ifPresent(
+                    cb ->
+                        ctx.onKey(
+                            new KeyCode.Enter(),
+                            (KeyEvent e) -> {
+                              if (n > 0 && props.isActivatable().test(items.get(sel))) {
+                                cb.accept(items.get(sel));
+                              }
+                              e.stopPropagation();
+                            }));
+          }
+
+          final int maxOffset = Math.max(0, n - 1);
+          final int liveOffset = offset;
+          ctx.onScroll(
+              (MouseEvent e) -> {
+                switch (e.kind()) {
+                  case SCROLL_UP -> offsetState.set(Math.max(0, liveOffset - SCROLL_STEP));
+                  case SCROLL_DOWN -> offsetState.set(Math.min(maxOffset, liveOffset + SCROLL_STEP));
+                  default -> {}
+                }
+              });
+
+          // Render the visible window.
+          List<Element> visible = new ArrayList<>();
+          int upper = Math.min(n, offset + visibleH);
+          for (int i = offset; i < upper; i++) {
+            final int idx = i;
+            final T item  = items.get(i);
+            visible.add(length(1, renderRow(props, item, idx, sel)));
+          }
+
+          if (visible.isEmpty()) return empty();
+          return column(visible.toArray(new Element[0]));
+        });
+  }
+
+  /// Move selection from `current` by `dir` (+1 / -1), skipping non-activatable rows. Returns
+  /// `null` if there's no further activatable row in that direction.
+  private static Integer moveSelection(List<Integer> activatableIdxs, int current, int dir) {
+    if (activatableIdxs.isEmpty()) return null;
+    int pos = activatableIdxs.indexOf(current);
+    int newPos;
+    if (pos < 0) {
+      // current isn't activatable; find the nearest activatable in the given direction.
+      if (dir > 0) {
+        int found = -1;
+        for (int i = 0; i < activatableIdxs.size(); i++) {
+          if (activatableIdxs.get(i) > current) { found = i; break; }
+        }
+        newPos = found;
+      } else {
+        int found = -1;
+        for (int i = activatableIdxs.size() - 1; i >= 0; i--) {
+          if (activatableIdxs.get(i) < current) { found = i; break; }
+        }
+        newPos = found;
+      }
+    } else {
+      newPos = pos + dir;
+    }
+    if (newPos < 0 || newPos >= activatableIdxs.size()) return null;
+    return activatableIdxs.get(newPos);
+  }
+
+  private static <T> Element renderRow(SelectableListProps<T> props, T item, int idx, int selected) {
+    final boolean isSel        = idx == selected;
+    final boolean activatable  = props.isActivatable().test(item);
+    return component(
+        ctx -> {
+          if (activatable) {
+            ctx.onClick(
+                (MouseEvent e) -> {
+                  if (isSel) {
+                    props.onActivate().ifPresent(cb -> cb.accept(item));
+                  } else {
+                    props.onSelectChange().accept(idx);
+                  }
+                  e.stopPropagation();
+                });
+          }
+          return props.rowRenderer().render(item, isSel);
+        });
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableList.java
@@ -7,6 +7,7 @@ import jatatui.react.Element;
 import jatatui.react.KeyEvent;
 import jatatui.react.MouseEvent;
 import jatatui.react.State;
+import jatatui.widgets.scrollbar.ScrollbarOrientation;
 import java.util.ArrayList;
 import java.util.List;
 import tui.crossterm.KeyCode;
@@ -19,7 +20,9 @@ import tui.crossterm.KeyCode;
 ///     them, Enter / Enter-on-click ignores them.
 ///
 /// Selection is controlled (parent owns `selected`, child notifies via `onSelectChange`); scroll
-/// offset is internal and clamped so the selected row is always visible.
+/// offset is internal and clamped so the selected row is always visible. When the content
+/// overflows the viewport and `props.showScrollbar()` is `true` (the default), a vertical-right
+/// scrollbar is rendered alongside the rows so the user can see their position in the list.
 ///
 /// Triggers:
 ///   - **Up / Down**: move selection to next/prev activatable row.
@@ -41,7 +44,7 @@ public final class SelectableList {
     return component(
         ctx -> {
           List<T> items = props.items();
-          int n         = items.size();
+          int n = items.size();
 
           // Indices of activatable rows — Up/Down skip everything else.
           List<Integer> activatableIdxs = new ArrayList<>();
@@ -53,7 +56,7 @@ public final class SelectableList {
           int sel = n == 0 ? 0 : Math.max(0, Math.min(props.selected(), n - 1));
 
           int areaHeight = ctx.area().map(Rect::height).orElse(20);
-          int visibleH   = Math.max(1, areaHeight);
+          int visibleH = Math.max(1, areaHeight);
 
           // Auto-scroll only when selection actually changed (or on first render). Without this
           // gate, mouse-wheel scrolls would be reverted on the next render — sel hadn't moved
@@ -66,9 +69,7 @@ public final class SelectableList {
           int offset = offsetState.get();
           if (selChanged) {
             int newOffset =
-                (sel < offset) ? sel
-                    : (sel >= offset + visibleH) ? sel - visibleH + 1
-                    : offset;
+                (sel < offset) ? sel : (sel >= offset + visibleH) ? sel - visibleH + 1 : offset;
             if (newOffset != offset) {
               offsetState.set(newOffset);
               offset = newOffset;
@@ -115,7 +116,8 @@ public final class SelectableList {
               (MouseEvent e) -> {
                 switch (e.kind()) {
                   case SCROLL_UP -> offsetState.set(Math.max(0, liveOffset - SCROLL_STEP));
-                  case SCROLL_DOWN -> offsetState.set(Math.min(maxOffset, liveOffset + SCROLL_STEP));
+                  case SCROLL_DOWN ->
+                      offsetState.set(Math.min(maxOffset, liveOffset + SCROLL_STEP));
                   default -> {}
                 }
               });
@@ -125,12 +127,29 @@ public final class SelectableList {
           int upper = Math.min(n, offset + visibleH);
           for (int i = offset; i < upper; i++) {
             final int idx = i;
-            final T item  = items.get(i);
+            final T item = items.get(i);
             visible.add(length(1, renderRow(props, item, idx, sel)));
           }
 
           if (visible.isEmpty()) return empty();
-          return column(visible.toArray(new Element[0]));
+
+          Element rowsColumn = column(visible.toArray(new Element[0]));
+
+          // Render a vertical-right scrollbar when content overflows and the caller wants it.
+          // We use the scrollbar component layered on top via stack so it doesn't steal a column
+          // from the row renderer — rows can use the full width up to the rightmost cell, and
+          // the scrollbar overpaints that last cell when present.
+          //
+          // Content overflows when n > visibleH; otherwise we render nothing (no scrollbar is
+          // visually noise for short lists) so callers get the same behaviour as before.
+          boolean overflows = props.showScrollbar() && n > visibleH;
+          if (overflows) {
+            Element bar =
+                jatatui.components.scrollbar.Components.scrollbar(
+                    offset, n, visibleH, ScrollbarOrientation.VerticalRight);
+            return stack(rowsColumn, bar);
+          }
+          return rowsColumn;
         });
   }
 
@@ -145,13 +164,19 @@ public final class SelectableList {
       if (dir > 0) {
         int found = -1;
         for (int i = 0; i < activatableIdxs.size(); i++) {
-          if (activatableIdxs.get(i) > current) { found = i; break; }
+          if (activatableIdxs.get(i) > current) {
+            found = i;
+            break;
+          }
         }
         newPos = found;
       } else {
         int found = -1;
         for (int i = activatableIdxs.size() - 1; i >= 0; i--) {
-          if (activatableIdxs.get(i) < current) { found = i; break; }
+          if (activatableIdxs.get(i) < current) {
+            found = i;
+            break;
+          }
         }
         newPos = found;
       }
@@ -162,9 +187,10 @@ public final class SelectableList {
     return activatableIdxs.get(newPos);
   }
 
-  private static <T> Element renderRow(SelectableListProps<T> props, T item, int idx, int selected) {
-    final boolean isSel        = idx == selected;
-    final boolean activatable  = props.isActivatable().test(item);
+  private static <T> Element renderRow(
+      SelectableListProps<T> props, T item, int idx, int selected) {
+    final boolean isSel = idx == selected;
+    final boolean activatable = props.isActivatable().test(item);
     return component(
         ctx -> {
           if (activatable) {

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
@@ -1,0 +1,99 @@
+package jatatui.components.selectablelist;
+
+import jatatui.react.Element;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.IntConsumer;
+
+/// Props for [SelectableList].
+///
+/// Sibling of [jatatui.components.list.ListComponent] but with:
+///   - **arbitrary [Element] rows** via [RowRenderer], not just labelled strings, and
+///   - **heterogeneous activatability** via [isActivatable] — schema headers, dividers, and
+///     other decorative rows live alongside selectable items; Up/Down skips the non-activatable
+///     ones, Enter only fires on activatable ones.
+///
+/// Selection is **controlled** (parent owns `selected`, child notifies via `onSelectChange`) —
+/// same pattern as [jatatui.components.list.ListComponent]. The widget's scroll offset is
+/// internal, automatically clamped so the selected row stays visible.
+///
+/// **Type parameter `T`** is the row payload type. It threads through [isActivatable],
+/// [RowRenderer], and [onActivate], so the compiler enforces consistency end to end.
+///
+/// Heterogeneous rendering is encoded in `T`:
+///
+/// ```
+/// sealed interface Row permits Row.Header, Row.Item { }
+/// record Header(String title) implements Row {}
+/// record Item(MyData data)    implements Row {}
+///
+/// SelectableListProps.of(
+///   rows,
+///   row -> row instanceof Item,
+///   (row, selected) -> switch (row) {
+///     case Header h -> text(h.title(), magenta);
+///     case Item it  -> renderItemRow(it, selected);
+///   },
+///   selectedIdx,
+///   newIdx -> ...,
+///   onActivate)
+/// ```
+public record SelectableListProps<T>(
+    List<T> items,
+    Predicate<T> isActivatable,
+    RowRenderer<T> rowRenderer,
+    int selected,
+    IntConsumer onSelectChange,
+    Optional<Consumer<T>> onActivate,
+    Optional<String> focusId,
+    boolean autoFocus) {
+
+  public SelectableListProps {
+    items = List.copyOf(items);
+  }
+
+  /// Minimal-args factory.
+  public static <T> SelectableListProps<T> of(
+      List<T> items,
+      Predicate<T> isActivatable,
+      RowRenderer<T> rowRenderer,
+      int selected,
+      IntConsumer onSelectChange) {
+    return new SelectableListProps<>(
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        Optional.empty(),
+        Optional.empty(),
+        true);
+  }
+
+  public SelectableListProps<T> withOnActivate(Consumer<T> onActivate) {
+    return new SelectableListProps<>(
+        items, isActivatable, rowRenderer, selected, onSelectChange, Optional.of(onActivate), focusId, autoFocus);
+  }
+
+  public SelectableListProps<T> withFocusId(String id) {
+    return new SelectableListProps<>(
+        items, isActivatable, rowRenderer, selected, onSelectChange, onActivate, Optional.of(id), autoFocus);
+  }
+
+  public SelectableListProps<T> withAutoFocus(boolean autoFocus) {
+    return new SelectableListProps<>(
+        items, isActivatable, rowRenderer, selected, onSelectChange, onActivate, focusId, autoFocus);
+  }
+
+  // ---- Type-safe lambda surrogates ----
+
+  /// Paint one row. `selected=true` when this row is highlighted; the renderer chooses how to
+  /// indicate selection (bg colour, caret, bold, etc.). Non-activatable rows still get called
+  /// with `selected=false`.
+  @FunctionalInterface
+  public interface RowRenderer<T> {
+    Element render(T item, boolean selected);
+  }
+}

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
@@ -46,6 +46,11 @@ import java.util.function.Predicate;
 /// disappears automatically when everything fits, so it costs nothing for short lists. Set it to
 /// `false` for embedded lists where reserving a right column would be visually awkward (a
 /// one-column-wide list, a list inside a tight modal, etc.).
+///
+/// **`activateOnDoubleClick`** controls click semantics. When `true` (default): single-click
+/// selects a row, double-click selects and activates. When `false`: single-click selects an
+/// unselected row, single-click on the already-selected row activates (the legacy behavior).
+/// Enter on the focused list activates the selected row regardless of this flag.
 public record SelectableListProps<T>(
     List<T> items,
     Predicate<T> isActivatable,
@@ -55,13 +60,14 @@ public record SelectableListProps<T>(
     Optional<Consumer<T>> onActivate,
     Optional<String> focusId,
     boolean autoFocus,
-    boolean showScrollbar) {
+    boolean showScrollbar,
+    boolean activateOnDoubleClick) {
 
   public SelectableListProps {
     items = List.copyOf(items);
   }
 
-  /// Minimal-args factory. Scrollbar is on by default.
+  /// Minimal-args factory. Scrollbar on, double-click activation on.
   public static <T> SelectableListProps<T> of(
       List<T> items,
       Predicate<T> isActivatable,
@@ -77,6 +83,7 @@ public record SelectableListProps<T>(
         Optional.empty(),
         Optional.empty(),
         true,
+        true,
         true);
   }
 
@@ -90,7 +97,8 @@ public record SelectableListProps<T>(
         Optional.of(onActivate),
         focusId,
         autoFocus,
-        showScrollbar);
+        showScrollbar,
+        activateOnDoubleClick);
   }
 
   public SelectableListProps<T> withFocusId(String id) {
@@ -103,7 +111,8 @@ public record SelectableListProps<T>(
         onActivate,
         Optional.of(id),
         autoFocus,
-        showScrollbar);
+        showScrollbar,
+        activateOnDoubleClick);
   }
 
   public SelectableListProps<T> withAutoFocus(boolean autoFocus) {
@@ -116,7 +125,8 @@ public record SelectableListProps<T>(
         onActivate,
         focusId,
         autoFocus,
-        showScrollbar);
+        showScrollbar,
+        activateOnDoubleClick);
   }
 
   public SelectableListProps<T> withShowScrollbar(boolean showScrollbar) {
@@ -129,7 +139,22 @@ public record SelectableListProps<T>(
         onActivate,
         focusId,
         autoFocus,
-        showScrollbar);
+        showScrollbar,
+        activateOnDoubleClick);
+  }
+
+  public SelectableListProps<T> withActivateOnDoubleClick(boolean activateOnDoubleClick) {
+    return new SelectableListProps<>(
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        onActivate,
+        focusId,
+        autoFocus,
+        showScrollbar,
+        activateOnDoubleClick);
   }
 
   // ---- Type-safe lambda surrogates ----

--- a/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
+++ b/jatatui-components/src/java/jatatui/components/selectablelist/SelectableListProps.java
@@ -4,8 +4,8 @@ import jatatui.react.Element;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.IntConsumer;
+import java.util.function.Predicate;
 
 /// Props for [SelectableList].
 ///
@@ -40,6 +40,12 @@ import java.util.function.IntConsumer;
 ///   newIdx -> ...,
 ///   onActivate)
 /// ```
+///
+/// **`showScrollbar`** controls whether a vertical-right scrollbar is rendered next to the rows
+/// when content overflows the viewport. Defaults to `true` — the visible state of the scrollbar
+/// disappears automatically when everything fits, so it costs nothing for short lists. Set it to
+/// `false` for embedded lists where reserving a right column would be visually awkward (a
+/// one-column-wide list, a list inside a tight modal, etc.).
 public record SelectableListProps<T>(
     List<T> items,
     Predicate<T> isActivatable,
@@ -48,13 +54,14 @@ public record SelectableListProps<T>(
     IntConsumer onSelectChange,
     Optional<Consumer<T>> onActivate,
     Optional<String> focusId,
-    boolean autoFocus) {
+    boolean autoFocus,
+    boolean showScrollbar) {
 
   public SelectableListProps {
     items = List.copyOf(items);
   }
 
-  /// Minimal-args factory.
+  /// Minimal-args factory. Scrollbar is on by default.
   public static <T> SelectableListProps<T> of(
       List<T> items,
       Predicate<T> isActivatable,
@@ -69,22 +76,60 @@ public record SelectableListProps<T>(
         onSelectChange,
         Optional.empty(),
         Optional.empty(),
+        true,
         true);
   }
 
   public SelectableListProps<T> withOnActivate(Consumer<T> onActivate) {
     return new SelectableListProps<>(
-        items, isActivatable, rowRenderer, selected, onSelectChange, Optional.of(onActivate), focusId, autoFocus);
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        Optional.of(onActivate),
+        focusId,
+        autoFocus,
+        showScrollbar);
   }
 
   public SelectableListProps<T> withFocusId(String id) {
     return new SelectableListProps<>(
-        items, isActivatable, rowRenderer, selected, onSelectChange, onActivate, Optional.of(id), autoFocus);
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        onActivate,
+        Optional.of(id),
+        autoFocus,
+        showScrollbar);
   }
 
   public SelectableListProps<T> withAutoFocus(boolean autoFocus) {
     return new SelectableListProps<>(
-        items, isActivatable, rowRenderer, selected, onSelectChange, onActivate, focusId, autoFocus);
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        onActivate,
+        focusId,
+        autoFocus,
+        showScrollbar);
+  }
+
+  public SelectableListProps<T> withShowScrollbar(boolean showScrollbar) {
+    return new SelectableListProps<>(
+        items,
+        isActivatable,
+        rowRenderer,
+        selected,
+        onSelectChange,
+        onActivate,
+        focusId,
+        autoFocus,
+        showScrollbar);
   }
 
   // ---- Type-safe lambda surrogates ----

--- a/jatatui-components/src/java/jatatui/components/textinput/TextInputComponent.java
+++ b/jatatui-components/src/java/jatatui/components/textinput/TextInputComponent.java
@@ -39,6 +39,13 @@ public final class TextInputComponent {
             registerKeyHandlers(ctx, props, cursorState);
           }
 
+          // Click-to-focus: clicking anywhere in the input's area imperatively focuses it.
+          // Only when focusId is set (otherwise there's no id to focus by) and the click would
+          // actually change focus (no-op when already focused).
+          if (props.focusOnClick() && !focused) {
+            props.focusId().ifPresent(id -> ctx.onClick(e -> ctx.focus(id)));
+          }
+
           int finalCursor = cursor;
           boolean finalFocused = focused;
           jatatui.core.widgets.Widget adapter =

--- a/jatatui-components/src/java/jatatui/components/textinput/TextInputProps.java
+++ b/jatatui-components/src/java/jatatui/components/textinput/TextInputProps.java
@@ -12,6 +12,10 @@ import java.util.function.Consumer;
 /// When `title` is non-empty, the input renders inside a bordered Block whose border style
 /// changes color when focused — the standard "this field is active" affordance. When empty, the
 /// input renders bare (no border) and the caller is responsible for any focus indication.
+///
+/// `focusOnClick` (default true): when `focusId` is set, clicking anywhere in the input's area
+/// imperatively focuses it. Set to false for inputs that participate in a click-pattern
+/// elsewhere (drag-to-select on parent, custom hit zones, etc).
 public record TextInputProps(
     String value,
     Consumer<String> onChange,
@@ -19,6 +23,7 @@ public record TextInputProps(
     String title,
     Optional<String> focusId,
     boolean autoFocus,
+    boolean focusOnClick,
     Optional<Runnable> onSubmit,
     Optional<Runnable> onCancel,
     Style style,
@@ -28,7 +33,8 @@ public record TextInputProps(
     Style borderStyle,
     Style focusedBorderStyle) {
 
-  /// Minimal-args factory: value + onChange. No placeholder, no title, default styles.
+  /// Minimal-args factory: value + onChange. No placeholder, no title, default styles,
+  /// `focusOnClick` enabled (no-op until `focusId` is set).
   public static TextInputProps of(String value, Consumer<String> onChange) {
     return new TextInputProps(
         value,
@@ -37,6 +43,7 @@ public record TextInputProps(
         "",
         Optional.empty(),
         false,
+        true,
         Optional.empty(),
         Optional.empty(),
         Style.empty(),
@@ -47,22 +54,23 @@ public record TextInputProps(
         Style.empty().withFg(new jatatui.core.style.Color.Yellow()));
   }
 
-  public TextInputProps withValue(String value) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnChange(Consumer<String> onChange) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withPlaceholder(String placeholder) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withTitle(String title) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusId(String focusId) { return copy(value, onChange, placeholder, title, Optional.of(focusId), autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withAutoFocus(boolean autoFocus) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnSubmit(Runnable onSubmit) { return copy(value, onChange, placeholder, title, focusId, autoFocus, Optional.of(onSubmit), onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnCancel(Runnable onCancel) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, Optional.of(onCancel), style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withStyle(Style style) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusedStyle(Style focusedStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withPlaceholderStyle(Style placeholderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withCursorStyle(Style cursorStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withBorderStyle(Style borderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusedBorderStyle(Style focusedBorderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withValue(String value) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withOnChange(Consumer<String> onChange) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withPlaceholder(String placeholder) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withTitle(String title) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withFocusId(String focusId) { return copy(value, onChange, placeholder, title, Optional.of(focusId), autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withAutoFocus(boolean autoFocus) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withFocusOnClick(boolean focusOnClick) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withOnSubmit(Runnable onSubmit) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, Optional.of(onSubmit), onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withOnCancel(Runnable onCancel) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, Optional.of(onCancel), style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withStyle(Style style) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withFocusedStyle(Style focusedStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withPlaceholderStyle(Style placeholderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withCursorStyle(Style cursorStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withBorderStyle(Style borderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withFocusedBorderStyle(Style focusedBorderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
 
-  private static TextInputProps copy(String value, Consumer<String> onChange, String placeholder, String title, Optional<String> focusId, boolean autoFocus, Optional<Runnable> onSubmit, Optional<Runnable> onCancel, Style style, Style focusedStyle, Style placeholderStyle, Style cursorStyle, Style borderStyle, Style focusedBorderStyle) {
-    return new TextInputProps(value, onChange, placeholder, title, focusId, autoFocus, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle);
+  private static TextInputProps copy(String value, Consumer<String> onChange, String placeholder, String title, Optional<String> focusId, boolean autoFocus, boolean focusOnClick, Optional<Runnable> onSubmit, Optional<Runnable> onCancel, Style style, Style focusedStyle, Style placeholderStyle, Style cursorStyle, Style borderStyle, Style focusedBorderStyle) {
+    return new TextInputProps(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle);
   }
 }

--- a/jatatui-demo-react/src/java/jatatui/react/examples/Launcher.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/Launcher.java
@@ -33,6 +33,7 @@ public final class Launcher {
     EXAMPLES.put("theme", "jatatui.react.examples.theme.ThemeExample");
     EXAMPLES.put("form", "jatatui.react.examples.form.FormExample");
     EXAMPLES.put("router", "jatatui.react.examples.router.RouterExample");
+    EXAMPLES.put("selectablelist", "jatatui.react.examples.selectablelist.SelectableListExample");
   }
 
   private Launcher() {}

--- a/jatatui-demo-react/src/java/jatatui/react/examples/selectablelist/SelectableListExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/selectablelist/SelectableListExample.java
@@ -1,0 +1,127 @@
+package jatatui.react.examples.selectablelist;
+
+import static jatatui.react.Components.box;
+import static jatatui.react.Components.column;
+import static jatatui.react.Components.component;
+import static jatatui.react.Components.fill;
+import static jatatui.react.Components.length;
+import static jatatui.react.Components.text;
+
+import jatatui.components.selectablelist.SelectableListProps;
+import jatatui.core.style.Color;
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+import jatatui.react.ReactApp;
+import jatatui.widgets.Borders;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/// Runnable demo for [jatatui.components.selectablelist.SelectableList].
+///
+/// The list is intentionally long (60 rows in a 10-row viewport-ish area) and contains a mix of
+/// non-activatable `Header` rows and activatable `Item` rows, so the demo exercises:
+///   - the vertical-right scrollbar that auto-shows when content overflows,
+///   - Up/Down skipping over non-activatable rows,
+///   - mouse-wheel scrolling without moving selection,
+///   - Enter/click to activate (records the most-recently-activated row in a status line).
+public final class SelectableListExample {
+
+  /// Heterogeneous payload — headers decorate the list, items are activatable.
+  sealed interface Row {
+    record Header(String title) implements Row {}
+
+    record Item(String name) implements Row {}
+  }
+
+  public static void main(String[] args) throws IOException {
+    ReactApp.run(app());
+  }
+
+  static Element app() {
+    return component(
+        ctx -> {
+          // Build a long list: 6 groups × (1 header + 10 items) = 66 rows.
+          List<Row> rows = buildRows();
+
+          // Initial selection: the first activatable row (idx 1, skipping the first header).
+          var selected = ctx.useState(() -> 1);
+          var lastActivated = ctx.useState(() -> "(none)");
+
+          SelectableListProps.RowRenderer<Row> renderer =
+              (row, isSel) ->
+                  switch (row) {
+                    case Row.Header h ->
+                        text(
+                            "── " + h.title() + " ─────────────────────────",
+                            Style.empty().withFg(Color.MAGENTA));
+                    case Row.Item it ->
+                        text(
+                            (isSel ? "> " : "  ") + it.name(),
+                            isSel
+                                ? Style.empty().withFg(Color.BLACK).withBg(Color.LIGHT_YELLOW)
+                                : Style.empty().withFg(Color.WHITE));
+                  };
+
+          Element listEl =
+              box(
+                  " SelectableList — long list with scrollbar ",
+                  Borders.ALL,
+                  jatatui.components.Components.selectableList(
+                      SelectableListProps.of(
+                              rows,
+                              r -> r instanceof Row.Item,
+                              renderer,
+                              selected.get(),
+                              selected::set)
+                          .withOnActivate(
+                              r -> {
+                                if (r instanceof Row.Item it) lastActivated.set(it.name());
+                              })
+                          .withFocusId("selectable-list-demo")
+                          .withAutoFocus(true)));
+
+          Row sel = rows.get(Math.max(0, Math.min(selected.get(), rows.size() - 1)));
+          String selLabel =
+              switch (sel) {
+                case Row.Header h -> "(header: " + h.title() + ")";
+                case Row.Item it -> it.name();
+              };
+
+          Element status =
+              box(
+                  " Status ",
+                  Borders.ALL,
+                  text(
+                      "Selected: "
+                          + selLabel
+                          + "   (idx "
+                          + selected.get()
+                          + " / "
+                          + rows.size()
+                          + ")",
+                      Style.empty().withFg(Color.YELLOW)),
+                  text(
+                      "Last activated: " + lastActivated.get(),
+                      Style.empty().withFg(Color.LIGHT_GREEN)),
+                  text(
+                      "Up/Down: move (skips headers) - Enter or click: activate - Wheel: scroll -"
+                          + " Esc to quit",
+                      Style.empty().withFg(Color.GRAY)));
+
+          return column(fill(1, listEl), length(5, status));
+        });
+  }
+
+  private static List<Row> buildRows() {
+    List<Row> rows = new ArrayList<>();
+    String[] groups = {"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"};
+    for (String g : groups) {
+      rows.add(new Row.Header(g));
+      for (int i = 1; i <= 10; i++) {
+        rows.add(new Row.Item(g.toLowerCase() + "-item-" + i));
+      }
+    }
+    return rows;
+  }
+}

--- a/jatatui-react/src/java/jatatui/react/FocusManager.java
+++ b/jatatui-react/src/java/jatatui/react/FocusManager.java
@@ -33,6 +33,13 @@ public final class FocusManager {
     registered.add(id);
     autoFocusFlags.put(id, autoFocus);
     idToFiber.put(id, fiber);
+    // Eager autoFocus claim: when nothing is focused, the first autoFocus registration this
+    // frame claims focus immediately so `useFocus` returns true on the SAME frame. Without
+    // this, the autoFocus winner is only chosen in [#commit] (after render), so the first
+    // frame paints as if nothing were focused.
+    if (autoFocus && focused.isEmpty()) {
+      focused = Optional.of(id);
+    }
   }
 
   /// The Fiber that owns `id`, if it registered this frame.

--- a/jatatui-react/src/java/jatatui/react/HookStore.java
+++ b/jatatui-react/src/java/jatatui/react/HookStore.java
@@ -18,6 +18,13 @@ final class HookStore {
   /// `(deps[], producedElement)`.
   final Map<Fiber, MemoEntry> memoCache = new HashMap<>();
 
+  /// What "type" was last rendered at each fiber position. Used by [RenderContext]'s
+  /// reconciliation step — when the type at a fiber changes between frames (e.g. a stack-based
+  /// router swaps SourceEditor for OutputEditor at the same fiber slot), the previous subtree
+  /// is unmounted (state dropped, cleanups run) before the new one renders. Mirrors React's
+  /// "different element type at same fiber → unmount + remount" rule.
+  final Map<Fiber, Object> elementTypes = new HashMap<>();
+
   // Note: there used to be an `applyCache` for Element.Of auto-memoization, but it interacted
   // badly with side-effect handlers (onClick/onKey/useFocus registrations would be dropped on
   // cache hit). Removed — memoization is opt-in only via memo() / pureComponent(), which use
@@ -46,6 +53,36 @@ final class HookStore {
     return true;
   }
 
+  // -------------------- unmount (reconciliation) --------------------
+
+  /// Drop all hook state for `root` and every descendant fiber, running cleanups. Used by
+  /// [RenderContext]'s reconciliation when the Element type at a fiber position changes between
+  /// frames — the old subtree is "unmounted" before the new one renders.
+  void unmount(Fiber root) {
+    Iterator<Map.Entry<HookKey, Runnable>> ci = cleanups.entrySet().iterator();
+    while (ci.hasNext()) {
+      Map.Entry<HookKey, Runnable> e = ci.next();
+      if (isInSubtree(root, e.getKey().fiber())) {
+        e.getValue().run();
+        ci.remove();
+      }
+    }
+    values.keySet().removeIf(k -> isInSubtree(root, k.fiber()));
+    deps.keySet().removeIf(k -> isInSubtree(root, k.fiber()));
+    memoCache.keySet().removeIf(f -> isInSubtree(root, f));
+    elementTypes.keySet().removeIf(f -> isInSubtree(root, f));
+  }
+
+  /// True if `f` is `root` or descended from it.
+  private static boolean isInSubtree(Fiber root, Fiber f) {
+    Fiber cur = f;
+    while (cur != null) {
+      if (cur.equals(root)) return true;
+      cur = cur.parent().orElse(null);
+    }
+    return false;
+  }
+
   // -------------------- sweep --------------------
 
   /// Drop hook state, memo cache, apply cache for fibers that weren't touched in the just-finished
@@ -63,6 +100,7 @@ final class HookStore {
       }
     }
     memoCache.keySet().removeIf(f -> !touched.contains(f));
+    elementTypes.keySet().removeIf(f -> !touched.contains(f));
     touched.clear();
   }
 

--- a/jatatui-react/src/java/jatatui/react/RenderContext.java
+++ b/jatatui-react/src/java/jatatui/react/RenderContext.java
@@ -184,6 +184,68 @@ public final class RenderContext {
     }
   }
 
+  /// Fire `callback` once on the render thread, `delayMs` after the component mounts (or after
+  /// `deps` change, if supplied). Cleaned up automatically on unmount — if the component is
+  /// unmounted before the timer fires, the callback never runs.
+  ///
+  /// Implementation: a shared daemon `ScheduledExecutorService` triggers
+  /// [#requestRerender] at the right time; the callback itself runs synchronously inside this
+  /// `useTimeout` call on the next render. So `state.set` / `router.push` / etc. from inside
+  /// the callback are safe — they execute on the loop thread, not on the executor thread.
+  ///
+  /// `deps`: same convention as [#useEffect]. Omitted or empty = "once on mount". Changed deps
+  /// cancel the in-flight timer and re-arm with a fresh delay.
+  public void useTimeout(long delayMs, Runnable callback, Object... deps) {
+    HookKey key = new HookKey(fiber, hookIndex++);
+    Object[] prev = hooks.deps.get(key);
+    boolean changed = prev == null || !arraysEqual(prev, deps);
+
+    TimeoutHookState state;
+    if (changed) {
+      Runnable cleanup = hooks.cleanups.remove(key);
+      if (cleanup != null) cleanup.run();
+      state = new TimeoutHookState();
+      state.fireAt = System.currentTimeMillis() + delayMs;
+      state.fired = false;
+      state.future =
+          TIMEOUT_SCHEDULER.schedule(
+              requestRerender, delayMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+      hooks.values.put(key, state);
+      final TimeoutHookState captured = state;
+      hooks.cleanups.put(
+          key,
+          () -> {
+            if (captured.future != null) captured.future.cancel(false);
+          });
+      hooks.deps.put(key, deps);
+    } else {
+      state = (TimeoutHookState) hooks.values.get(key);
+    }
+
+    if (!state.fired && System.currentTimeMillis() >= state.fireAt) {
+      state.fired = true;
+      callback.run();
+    }
+  }
+
+  /// Mutable hook-store entry for [#useTimeout].
+  static final class TimeoutHookState {
+    long fireAt;
+    boolean fired;
+    java.util.concurrent.ScheduledFuture<?> future;
+  }
+
+  /// Shared daemon executor for [#useTimeout]. One thread per process, regardless of how many
+  /// hooks are armed. Spawning a thread per timer would not scale; this matches what
+  /// [jatatui.components.toast.ToastsProvider] already does for its own timer needs.
+  private static final java.util.concurrent.ScheduledExecutorService TIMEOUT_SCHEDULER =
+      java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "jatatui-react-timeouts");
+            t.setDaemon(true);
+            return t;
+          });
+
   // ---- Portal ----
 
   /// Queue a portal for deferred rendering after the main pass. Called by the Portal intrinsic;

--- a/jatatui-react/src/java/jatatui/react/RenderContext.java
+++ b/jatatui-react/src/java/jatatui/react/RenderContext.java
@@ -82,6 +82,7 @@ public final class RenderContext {
     hookIndex = 0;
     hooks.touched.add(fiber);
     events.recordBounds(fiber, area);
+    reconcile(fiber, child);
     try {
       child.render(this, area);
     } finally {
@@ -97,12 +98,47 @@ public final class RenderContext {
     hookIndex = 0;
     hooks.touched.add(fiber);
     events.recordBounds(fiber, area);
+    reconcile(fiber, child);
     try {
       child.render(this, area);
     } finally {
       fiber = prev;
       hookIndex = prevHook;
     }
+  }
+
+  /// Reconciliation: when the type at `fiber` changes between frames (e.g. a Router swaps
+  /// SourceEditor for OutputEditor at the same fiber slot), the old subtree is unmounted —
+  /// state dropped, cleanups run — before the new one renders. Mirrors React's "different
+  /// element type at same fiber → unmount + remount" rule.
+  ///
+  /// "Type" means the [Component] reference for [Element.Of], the `Element.Host` class for
+  /// host leaves, and recursively the child's type for the transparent [Element.Sized].
+  /// `component(...)`-wrapped functions all share the FUNCTION Component reference, so we
+  /// special-case them and use the body lambda's class identity (different `component(...)`
+  /// call sites produce different anonymous-lambda classes; same call site produces the same
+  /// class even across renders).
+  private void reconcile(Fiber f, Element child) {
+    Object newType = typeOf(child);
+    Object oldType = hooks.elementTypes.get(f);
+    if (oldType != null && !oldType.equals(newType)) {
+      hooks.unmount(f);
+    }
+    hooks.elementTypes.put(f, newType);
+  }
+
+  private static Object typeOf(Element e) {
+    if (e instanceof Element.Of<?> of) {
+      if (of.type() == Intrinsics.FUNCTION) {
+        Intrinsics.FunctionProps fp = (Intrinsics.FunctionProps) of.props();
+        return fp.body().getClass();
+      }
+      return of.type();
+    }
+    if (e instanceof Element.Sized s) {
+      return typeOf(s.child());
+    }
+    return e.getClass();
   }
 
   /// Apply an [Element.Of] — runs the component body unconditionally. Memoization is opt-in via

--- a/jatatui-react/src/java/jatatui/react/RenderContext.java
+++ b/jatatui-react/src/java/jatatui/react/RenderContext.java
@@ -208,6 +208,24 @@ public final class RenderContext {
     return focus.isFocused(fid);
   }
 
+  /// Imperatively move focus to the focusable with this `id`. Use from event handlers (click,
+  /// validation-failed callbacks, list-row selection — anywhere you need to focus a specific
+  /// component without going through Tab cycling). Pairs with [#useFocus]'s explicit `id`.
+  ///
+  /// Effective on the next render: focus state is read by `useFocus` during render, and this
+  /// just stages the new focused id.
+  public void focus(String id) {
+    focus.focus(id);
+    requestRerender.run();
+  }
+
+  /// Imperatively clear focus. Next render's `useFocus` calls all return false until something
+  /// claims focus again (Tab cycling, autoFocus, or [#focus(String)]).
+  public void blur() {
+    focus.blur();
+    requestRerender.run();
+  }
+
   // ---- Event registration ----
 
   /// The bounds for this Component's fiber, recorded by the parent's `renderChild` call. Returns

--- a/jatatui-react/src/java/jatatui/react/Renderer.java
+++ b/jatatui-react/src/java/jatatui/react/Renderer.java
@@ -70,12 +70,21 @@ public final class Renderer {
   public void render(Frame frame, Element root) {
     events.clear();
     focus.clearFrame();
+    java.util.Optional<String> focusedBefore = focus.currentlyFocused();
     RenderContext ctx = new RenderContext(frame, events, hooks, focus, this::requestRerender);
     events.recordBounds(Fiber.root(), frame.area());
     root.render(ctx, frame.area());
     ctx.drainPortals();
     hooks.sweep();
     focus.commit();
+    // Screen-change case: the previously focused id wasn't re-registered this frame so commit
+    // chose a new winner (or the previously focused element unmounted). Request a re-render so
+    // the new winner is visible — this frame painted as if nothing were focused there.
+    // First-render and post-blur cases are handled eagerly inside FocusManager.register, so this
+    // re-request only fires when we genuinely need a second pass.
+    if (!focus.currentlyFocused().equals(focusedBefore)) {
+      requestRerender();
+    }
   }
 
   // ---- Event dispatch ----

--- a/jatatui-tests/src/java/jatatui/components/button/ButtonTest.java
+++ b/jatatui-tests/src/java/jatatui/components/button/ButtonTest.java
@@ -1,0 +1,65 @@
+package jatatui.components.button;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.layout.Margin;
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyCode;
+import tui.crossterm.KeyModifiers;
+
+class ButtonTest {
+
+  @Test
+  void click_activates() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app =
+        column(
+                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 10);
+    h.render(app);
+    h.renderer.dispatchMouse(new MouseEvent(2, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, n.get());
+  }
+
+  @Test
+  void enter_activates_when_focused() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app =
+        column(
+                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 10);
+    h.render(app);
+    h.renderer.tab(); // focus the button
+    h.render(app);
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals(1, n.get());
+  }
+
+  @Test
+  void enter_does_nothing_when_not_focused() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app =
+        column(
+                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 10);
+    h.render(app);
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals(0, n.get(), "no focus → Enter is a noop");
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/chrome/BackButtonTest.java
+++ b/jatatui-tests/src/java/jatatui/components/chrome/BackButtonTest.java
@@ -1,0 +1,48 @@
+package jatatui.components.chrome;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.layout.Margin;
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyModifiers;
+
+class BackButtonTest {
+
+  @Test
+  void click_inside_chip_invokes_back() throws IOException {
+    AtomicInteger backCount = new AtomicInteger();
+    Element app =
+        column(length(BackButton.HEIGHT, BackButton.of("sources", backCount::incrementAndGet)),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(60, 12);
+    h.render(app);
+
+    // Chip width = "sources".length() + 5 = 12. Click in the middle of the chip.
+    h.renderer.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, backCount.get());
+  }
+
+  @Test
+  void click_past_chip_edge_does_not_invoke_back() throws IOException {
+    AtomicInteger backCount = new AtomicInteger();
+    Element app =
+        column(length(BackButton.HEIGHT, BackButton.of("x", backCount::incrementAndGet)),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(60, 12);
+    h.render(app);
+
+    // Chip width = "x".length() + 5 = 6. Click far past it at x=40 — should fall through.
+    h.renderer.dispatchMouse(new MouseEvent(40, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(0, backCount.get());
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/chrome/ScreenFrameTest.java
+++ b/jatatui-tests/src/java/jatatui/components/chrome/ScreenFrameTest.java
@@ -1,0 +1,49 @@
+package jatatui.components.chrome;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyModifiers;
+
+class ScreenFrameTest {
+
+  /// Body content's first useFocus(autoFocus=true) should claim focus — ScreenFrame's
+  /// BackButton is intentionally not focusable, so the focus chain starts with content.
+  @Test
+  void body_first_focusable_claims_focus() throws IOException {
+    AtomicBoolean innerFocused = new AtomicBoolean();
+    Element body =
+        component(
+            ctx -> {
+              boolean f = ctx.useFocus(Optional.of("inner"), true);
+              innerFocused.set(f);
+              return text("body");
+            });
+
+    Element app = ScreenFrame.of("home", () -> {}, body);
+
+    TestHarness h = new TestHarness(40, 12);
+    h.render(app);
+    assertTrue(innerFocused.get(), "body's autoFocus claims focus same-frame (eager-claim)");
+  }
+
+  @Test
+  void clicking_back_chip_invokes_back() throws IOException {
+    AtomicInteger backCount = new AtomicInteger();
+    Element app =
+        ScreenFrame.of("home", backCount::incrementAndGet, text("body"));
+
+    TestHarness h = new TestHarness(40, 12);
+    h.render(app);
+    h.renderer.dispatchMouse(new MouseEvent(2, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, backCount.get());
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
+++ b/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
@@ -108,6 +108,83 @@ class DropdownTest {
     assertEquals(2, selected.get(), "highlight moved 0 → 1 → 2 (blue)");
   }
 
+  /// Cursor-then-Tab commits: navigating with Up/Down and then Tab'ing away takes the current
+  /// highlight as the selection (rather than discarding it). Cancel paths — Esc, backdrop
+  /// click — go through different branches and stay non-committing.
+  @Test
+  void tab_with_moved_highlight_commits_selection() throws IOException {
+    AtomicInteger selected = new AtomicInteger(0);
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3, dropdown("A", List.of("red", "green", "blue"),
+                    selected.get(),
+                    i -> {
+                      selected.set(i);
+                      changeCount.incrementAndGet();
+                    },
+                    "a")),
+                length(3, dropdown("B", List.of("p", "q"), 0, i -> {}, "b")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open A.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    // Move highlight 0 → 1 → 2 (blue).
+    h.renderer.dispatchKey(
+        new jatatui.react.KeyEvent(new tui.crossterm.KeyCode.Down(), new KeyModifiers(0)));
+    h.render(app);
+    h.renderer.dispatchKey(
+        new jatatui.react.KeyEvent(new tui.crossterm.KeyCode.Down(), new KeyModifiers(0)));
+    h.render(app);
+
+    // Tab to B (in real app, ReactApp does focus.tab; here we call it directly). The auto-
+    // close branch should commit the current highlight (blue, index 2).
+    h.renderer.tab();
+    h.render(app);
+
+    assertEquals(1, changeCount.get(), "Tab away with moved highlight commits exactly once");
+    assertEquals(2, selected.get(), "blue is the selection (index 2)");
+  }
+
+  /// Opening then Tab'ing away without moving the highlight does NOT fire onChange (no real
+  /// change to commit).
+  @Test
+  void tab_without_moving_highlight_does_not_fire_onchange() throws IOException {
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3, dropdown("A", List.of("red", "green", "blue"),
+                    1, // start with green selected
+                    i -> changeCount.incrementAndGet(),
+                    "a")),
+                length(3, dropdown("B", List.of("p", "q"), 0, i -> {}, "b")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open A (highlight initialized to selectedIndex = 1).
+    h.events.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    // Tab away — same highlight as selection, no onChange.
+    h.renderer.tab();
+    h.render(app);
+
+    assertEquals(0, changeCount.get(), "no movement, no commit");
+  }
+
   /// Tab while the dropdown is open: ReactApp's loop moves focus to the next focusable. The
   /// dropdown's auto-close-on-focus-loss closes the open list. (Focus arrives at the next
   /// dropdown via FocusManager.tab in a real loop; here we exercise the auto-close branch.)

--- a/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
+++ b/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
@@ -1,0 +1,182 @@
+package jatatui.components.dropdown;
+
+import static jatatui.components.Components.dropdown;
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.layout.Margin;
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyModifiers;
+
+class DropdownTest {
+
+  /// Open the dropdown by clicking the trigger; click an option row; the selection commits and
+  /// the dropdown closes. Without per-row click handlers, the only way to commit was Enter,
+  /// which made the dropdown effectively keyboard-only.
+  @Test
+  void click_on_option_row_commits_selection_and_closes() throws IOException {
+    AtomicInteger selected = new AtomicInteger(0);
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3, dropdown("Color", List.of("red", "green", "blue", "yellow"),
+                    selected.get(),
+                    i -> {
+                      selected.set(i);
+                      changeCount.incrementAndGet();
+                    },
+                    "color")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Click the trigger (top of the column, rows 0..2). Anywhere in row 1 lands inside the box.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    // Now the option list is open just below the trigger. Default size: 4 items + 2 borders =
+    // 6 rows starting at y=3. Row content (after the top border at y=3) starts at y=4.
+    // Click on the third item ("blue") which sits at y=6.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    assertEquals(1, changeCount.get(), "click on option row should fire onChange exactly once");
+    assertEquals(2, selected.get(), "blue (index 2) selected");
+
+    // After committing, dropdown should be closed — re-render shouldn't paint the option list,
+    // and clicking where the option list was should NOT re-commit.
+    int countBefore = changeCount.get();
+    h.events.dispatchMouse(
+        new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(countBefore, changeCount.get(), "dropdown is closed; click does not commit");
+  }
+
+  /// Up/Down move the highlight and Enter commits — keys are registered on the dropdown's own
+  /// fiber (not on the overlay's portal subtree, which is descendant of the dropdown and so
+  /// outside the focused-bubble chain).
+  @Test
+  void keyboard_navigation_works_when_open() throws IOException {
+    AtomicInteger selected = new AtomicInteger(0);
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3, dropdown("Color", List.of("red", "green", "blue"),
+                    selected.get(),
+                    i -> {
+                      selected.set(i);
+                      changeCount.incrementAndGet();
+                    },
+                    "color")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open with click — also focuses the dropdown.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    // Press Down twice: highlight 0 → 1 → 2 (blue).
+    h.renderer.dispatchKey(
+        new jatatui.react.KeyEvent(new tui.crossterm.KeyCode.Down(), new KeyModifiers(0)));
+    h.render(app);
+    h.renderer.dispatchKey(
+        new jatatui.react.KeyEvent(new tui.crossterm.KeyCode.Down(), new KeyModifiers(0)));
+    h.render(app);
+
+    // Commit with Enter.
+    h.renderer.dispatchKey(
+        new jatatui.react.KeyEvent(new tui.crossterm.KeyCode.Enter(), new KeyModifiers(0)));
+    h.render(app);
+
+    assertEquals(1, changeCount.get(), "Enter commits exactly once");
+    assertEquals(2, selected.get(), "highlight moved 0 → 1 → 2 (blue)");
+  }
+
+  /// Tab while the dropdown is open: ReactApp's loop moves focus to the next focusable. The
+  /// dropdown's auto-close-on-focus-loss closes the open list. (Focus arrives at the next
+  /// dropdown via FocusManager.tab in a real loop; here we exercise the auto-close branch.)
+  @Test
+  void losing_focus_closes_open_dropdown() throws IOException {
+    Element app =
+        column(
+                length(3, dropdown("A", List.of("x", "y"), 0, i -> {}, "a")),
+                length(3, dropdown("B", List.of("p", "q"), 0, i -> {}, "b")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open the first dropdown.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(java.util.Optional.of("a"), h.focus.currentlyFocused(),
+        "click on A's trigger focused A");
+
+    // Move focus to B (Tab in ReactApp would do focus.tab(); we call it directly for the test).
+    h.renderer.tab();
+    h.render(app);
+    assertEquals(java.util.Optional.of("b"), h.focus.currentlyFocused(),
+        "focus moved to B");
+
+    // The first dropdown's open list should no longer respond — Down on B doesn't change A.
+    // We can't easily inspect openState directly, but the symptom would be: clicking where A's
+    // open-list used to be re-fires onChange. After auto-close, that click does nothing.
+    h.events.dispatchMouse(
+        new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    // No commit happened on either dropdown — implicit assertion (no exception, focus still B).
+    assertEquals(java.util.Optional.of("b"), h.focus.currentlyFocused());
+  }
+
+  /// Backdrop click outside the option list closes the dropdown WITHOUT committing.
+  @Test
+  void backdrop_click_closes_without_committing() throws IOException {
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3, dropdown("Color", List.of("red", "green", "blue"),
+                    0,
+                    i -> changeCount.incrementAndGet(),
+                    "color")),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open it.
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    // Click far below the option list (somewhere on the backdrop, outside both trigger and
+    // option list). Default list at y=3..7-ish; click at y=18 is well below.
+    h.events.dispatchMouse(new MouseEvent(20, 18, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    assertEquals(0, changeCount.get(), "backdrop click does not change selection");
+
+    // Verify list closed by clicking where an option used to be — no commit.
+    h.events.dispatchMouse(new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(0, changeCount.get());
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
+++ b/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
@@ -108,6 +108,45 @@ class DropdownTest {
     assertEquals(2, selected.get(), "highlight moved 0 → 1 → 2 (blue)");
   }
 
+  /// Dropdown is generic over `T` — typed options (here an enum) work with a labelFn.
+  enum Color { RED, GREEN, BLUE }
+
+  @Test
+  void typed_options_via_labelfn() throws IOException {
+    AtomicInteger selected = new AtomicInteger(0);
+    AtomicInteger changeCount = new AtomicInteger(0);
+
+    Element app =
+        column(
+                length(3,
+                    jatatui.components.Components.dropdown(
+                        DropdownProps.of(
+                                "Color",
+                                java.util.Arrays.asList(Color.RED, Color.GREEN, Color.BLUE),
+                                c -> c.name().toLowerCase(),
+                                selected.get(),
+                                i -> {
+                                  selected.set(i);
+                                  changeCount.incrementAndGet();
+                                })
+                            .withFocusId("color")
+                            .withAutoFocus(true))),
+                fill(1, text("")))
+            .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+
+    // Open with click, then click the second option (GREEN at y=5).
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    h.events.dispatchMouse(new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    assertEquals(1, changeCount.get());
+    assertEquals(1, selected.get(), "GREEN = index 1");
+  }
+
   /// Cursor-then-Tab commits: navigating with Up/Down and then Tab'ing away takes the current
   /// highlight as the selection (rather than discarding it). Cancel paths — Esc, backdrop
   /// click — go through different branches and stay non-committing.

--- a/jatatui-tests/src/java/jatatui/components/link/LinkTest.java
+++ b/jatatui-tests/src/java/jatatui/components/link/LinkTest.java
@@ -1,0 +1,72 @@
+package jatatui.components.link;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyCode;
+import tui.crossterm.KeyModifiers;
+
+class LinkTest {
+
+  @Test
+  void click_invokes_onactivate() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app = Link.focusable(true, n::incrementAndGet, focused -> text("link"));
+
+    TestHarness h = new TestHarness(40, 5);
+    h.render(app);
+    h.renderer.dispatchMouse(new MouseEvent(2, 0, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, n.get());
+  }
+
+  @Test
+  void enter_when_focused_invokes_onactivate() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app = Link.focusable(true, n::incrementAndGet, focused -> text("link"));
+
+    TestHarness h = new TestHarness(40, 5);
+    h.render(app);
+    h.render(app); // eager-claim already focused; render once more to settle
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals(1, n.get());
+  }
+
+  @Test
+  void content_receives_live_focused_flag() throws IOException {
+    java.util.List<Boolean> seen = new java.util.ArrayList<>();
+    Element app =
+        Link.focusable(
+            true,
+            () -> {},
+            focused -> {
+              seen.add(focused);
+              return text("link");
+            });
+
+    TestHarness h = new TestHarness(40, 5);
+    h.render(app);
+    assertEquals(java.util.List.of(true), seen, "autoFocus=true → first render sees focused=true");
+  }
+
+  @Test
+  void click_variant_not_focusable_but_clickable() throws IOException {
+    AtomicInteger n = new AtomicInteger();
+    Element app = Link.click(n::incrementAndGet, text("plain"));
+
+    TestHarness h = new TestHarness(40, 5);
+    h.render(app);
+    // No useFocus → nothing focused on the link. Click still fires.
+    h.renderer.dispatchMouse(new MouseEvent(2, 0, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, n.get());
+    // Enter does nothing (no key handler registered).
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals(1, n.get());
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/modal/ConfirmDialogTest.java
+++ b/jatatui-tests/src/java/jatatui/components/modal/ConfirmDialogTest.java
@@ -1,0 +1,80 @@
+package jatatui.components.modal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyCode;
+import tui.crossterm.KeyModifiers;
+
+class ConfirmDialogTest {
+
+  @Test
+  void esc_fires_oncancel() throws IOException {
+    AtomicInteger confirmCount = new AtomicInteger();
+    AtomicInteger cancelCount = new AtomicInteger();
+    Element app =
+        ConfirmDialog.of(
+            true,
+            " Delete ",
+            "Are you sure?",
+            "Delete",
+            "Keep",
+            true,
+            confirmCount::incrementAndGet,
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(100, 30);
+    h.render(app);
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Esc(), new KeyModifiers(0)));
+    assertEquals(1, cancelCount.get());
+    assertEquals(0, confirmCount.get());
+  }
+
+  @Test
+  void backdrop_click_fires_oncancel() throws IOException {
+    AtomicInteger cancelCount = new AtomicInteger();
+    Element app =
+        ConfirmDialog.of(
+            true,
+            " Delete ",
+            "?",
+            "Yes",
+            "No",
+            false,
+            () -> {},
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(100, 30);
+    h.render(app);
+    // Dialog is 60x11 centered in 100x30 → box at (20..79, 9..19). Click in the backdrop area.
+    h.renderer.dispatchMouse(new MouseEvent(5, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, cancelCount.get());
+  }
+
+  @Test
+  void closed_dialog_does_not_intercept_clicks() throws IOException {
+    AtomicInteger cancelCount = new AtomicInteger();
+    Element app =
+        ConfirmDialog.of(
+            false,
+            " Delete ",
+            "?",
+            "Yes",
+            "No",
+            false,
+            () -> {},
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(100, 30);
+    h.render(app);
+    h.renderer.dispatchMouse(new MouseEvent(50, 15, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(0, cancelCount.get(), "closed dialog renders nothing → no backdrop → no cancel");
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
+++ b/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
@@ -210,6 +210,49 @@ class PickerTest {
     assertEquals("  no matches", line.toString());
   }
 
+  /// When the host has another focusable rendered alongside (or before) the picker — typical
+  /// pattern: a list underneath, picker overlaid on top via conditional render — the picker
+  /// must still grab focus so keystrokes go to its query field instead of leaking to the host.
+  /// Without the on-mount useEffect, FocusManager's eager-claim wouldn't fire (focus already
+  /// held by the list) and the user's typing would route to the list's onKey handlers.
+  @Test
+  void picker_steals_focus_on_mount_even_with_competing_focusable() throws IOException {
+    java.util.concurrent.atomic.AtomicBoolean showPicker =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("a", "b", "c")),
+            textRow(),
+            s -> {},
+            () -> {});
+
+    Element app =
+        component(
+            ctx -> {
+              // Host's focusable, registered first → claims focus on first frame.
+              ctx.useFocus(java.util.Optional.of("host-list"), true);
+              return showPicker.get() ? Picker.of(props) : text("(closed)");
+            });
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(app);
+    h.render(app);
+    assertEquals(
+        java.util.Optional.of("host-list"),
+        h.focus.currentlyFocused(),
+        "host's autoFocus claims focus while picker is closed");
+
+    showPicker.set(true);
+    h.render(app);
+
+    assertEquals(
+        java.util.Optional.of(Picker.QUERY_FOCUS_ID),
+        h.focus.currentlyFocused(),
+        "picker's on-mount useEffect steals focus from the host's list");
+  }
+
   @Test
   void hint_can_be_dropped() throws IOException {
     PickerProps<String> withHint =

--- a/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
+++ b/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
@@ -1,0 +1,231 @@
+package jatatui.components.picker;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyCode;
+import tui.crossterm.KeyModifiers;
+
+class PickerTest {
+
+  /// Helper: trivial substring filter over a fixed list.
+  static PickerProps.Filter<String> substring(List<String> items) {
+    return q ->
+        items.stream()
+            .filter(s -> q.isEmpty() || s.toLowerCase().contains(q.toLowerCase()))
+            .toList();
+  }
+
+  /// Helper: row renderer that returns text with a marker for selection.
+  static PickerProps.RowRenderer<String> textRow() {
+    return (item, selected) -> text((selected ? "> " : "  ") + item, Style.empty());
+  }
+
+  /// Helper: build a picker rendered alone, big enough that the modal sits in the middle.
+  static Element pickerApp(PickerProps<String> props) {
+    return props == null ? text("") : Picker.of(props);
+  }
+
+  @Test
+  void enter_fires_onselect_with_highlighted_item() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    AtomicInteger cancelCount = new AtomicInteger();
+
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("apple", "banana", "cherry")),
+            textRow(),
+            selected::set,
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    // Enter on the first item (highlight defaults to 0).
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals("apple", selected.get());
+    assertEquals(0, cancelCount.get(), "Enter does not cancel");
+  }
+
+  @Test
+  void down_then_enter_picks_second_item() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("apple", "banana", "cherry")),
+            textRow(),
+            selected::set,
+            () -> {});
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Down(), new KeyModifiers(0)));
+    h.render(pickerApp(props));
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals("banana", selected.get());
+  }
+
+  @Test
+  void up_clamps_at_zero() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("a", "b", "c")),
+            textRow(),
+            selected::set,
+            () -> {});
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    // Press Up multiple times — selection clamps at 0.
+    for (int i = 0; i < 5; i++) {
+      h.renderer.dispatchKey(new KeyEvent(new KeyCode.Up(), new KeyModifiers(0)));
+      h.render(pickerApp(props));
+    }
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals("a", selected.get());
+  }
+
+  @Test
+  void down_clamps_at_size_minus_one() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("a", "b", "c")),
+            textRow(),
+            selected::set,
+            () -> {});
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    for (int i = 0; i < 10; i++) {
+      h.renderer.dispatchKey(new KeyEvent(new KeyCode.Down(), new KeyModifiers(0)));
+      h.render(pickerApp(props));
+    }
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals("c", selected.get());
+  }
+
+  @Test
+  void esc_fires_oncancel() throws IOException {
+    AtomicInteger cancelCount = new AtomicInteger();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("a", "b")),
+            textRow(),
+            s -> {},
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Esc(), new KeyModifiers(0)));
+    assertEquals(1, cancelCount.get());
+  }
+
+  @Test
+  void click_outside_modal_fires_oncancel() throws IOException {
+    AtomicInteger cancelCount = new AtomicInteger();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("a", "b")),
+            textRow(),
+            s -> {},
+            cancelCount::incrementAndGet);
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    // Picker is 80x20 centered in 120x30 → modal covers (20..99, 5..24). Click at (5, 1) is
+    // outside.
+    h.renderer.dispatchMouse(
+        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals(1, cancelCount.get());
+  }
+
+  @Test
+  void click_on_row_fires_onselect_with_that_row() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            substring(List.of("apple", "banana", "cherry")),
+            textRow(),
+            selected::set,
+            () -> {});
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    // Modal centered in 120x30 with size 80x20 → top-left at (20, 5). Inside the box border
+    // the textinput takes 3 rows, then results start at y = 5 + 1 (top border) + 3 (input).
+    // First result row is at y = 9. Click on it.
+    h.renderer.dispatchMouse(
+        new MouseEvent(30, 9, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    assertEquals("apple", selected.get());
+  }
+
+  @Test
+  void empty_results_renders_no_matches_line_and_enter_is_noop() throws IOException {
+    AtomicReference<String> selected = new AtomicReference<>();
+    PickerProps<String> props =
+        PickerProps.of(
+            " Pick ",
+            q -> List.of(), // always empty
+            textRow(),
+            selected::set,
+            () -> {});
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(props));
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertNull(selected.get(), "Enter on empty results does not commit anything");
+
+    // Spot-check the rendered cell where "  no matches" is painted.
+    var buf = h.backend.buffer();
+    StringBuilder line = new StringBuilder();
+    int y = 5 + 1 + 3; // box top + top border + 3-row input
+    for (int x = 21; x < 21 + 12; x++) line.append(buf.cellAt(x, y).symbol());
+    assertEquals("  no matches", line.toString());
+  }
+
+  @Test
+  void hint_can_be_dropped() throws IOException {
+    PickerProps<String> withHint =
+        PickerProps.of(" Pick ", substring(List.of("a")), textRow(), s -> {}, () -> {});
+    PickerProps<String> withoutHint = withHint.withoutHint();
+
+    TestHarness h = new TestHarness(120, 30);
+    h.render(pickerApp(withoutHint));
+
+    // The hint line in the default props starts with "  up/down navigate". Verify it's NOT
+    // painted in the box's bottom-content row.
+    var buf = h.backend.buffer();
+    int y = 5 + 20 - 2; // box top + height - 1 (bottom border) - 1 (hint row, only when present)
+    StringBuilder line = new StringBuilder();
+    for (int x = 21; x < 21 + 16; x++) line.append(buf.cellAt(x, y).symbol());
+    assertNotEquals("  up/down navi", line.toString().substring(0, 14));
+    assertEquals(Optional.empty(), withoutHint.hint());
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/router/RouterTest.java
+++ b/jatatui-tests/src/java/jatatui/components/router/RouterTest.java
@@ -104,6 +104,53 @@ class RouterTest {
     assertEquals(2, apiRef.get().depth());
   }
 
+  /// Router transitions clear focus before the new screen renders, so the new screen's
+  /// `useFocus(autoFocus=true)` claims SAME-frame via the eager-claim path. Without this, the
+  /// previous screen's focused id would still be set, blocking eager-claim, and the new
+  /// screen's first frame would paint as nothing-focused (one-frame flicker).
+  @Test
+  void push_clears_focus_so_new_screen_focuses_first_frame() throws IOException {
+    AtomicReference<RouterApi> apiRef = new AtomicReference<>();
+    java.util.List<Boolean> screenAFlags = new java.util.ArrayList<>();
+    java.util.List<Boolean> screenBFlags = new java.util.ArrayList<>();
+
+    Element screenA =
+        component(
+            ctx -> {
+              apiRef.set(RouterApi.useRouter(ctx));
+              screenAFlags.add(ctx.useFocus(java.util.Optional.of("a-field"), true));
+              return text("a");
+            });
+    Element screenB =
+        component(
+            ctx -> {
+              apiRef.set(RouterApi.useRouter(ctx));
+              screenBFlags.add(ctx.useFocus(java.util.Optional.of("b-field"), true));
+              return text("b");
+            });
+
+    Element app = router(Screen.of("a", screenA));
+    TestHarness h = new TestHarness(40, 12);
+
+    h.render(app);
+    assertEquals(java.util.List.of(true), screenAFlags, "screen A's autoFocus visible same-frame");
+
+    apiRef.get().push("b", screenB);
+    h.render(app);
+    assertEquals(
+        java.util.List.of(true),
+        screenBFlags,
+        "screen B's autoFocus visible same-frame (router cleared stale focus from A)");
+
+    screenAFlags.clear();
+    apiRef.get().pop();
+    h.render(app);
+    assertEquals(
+        java.util.List.of(true),
+        screenAFlags,
+        "back to screen A: autoFocus visible same-frame again");
+  }
+
   @Test
   void reset_back_to_base() throws IOException {
     AtomicReference<RouterApi> apiRef = new AtomicReference<>();

--- a/jatatui-tests/src/java/jatatui/components/scrollable/ScrollableTest.java
+++ b/jatatui-tests/src/java/jatatui/components/scrollable/ScrollableTest.java
@@ -1,0 +1,91 @@
+package jatatui.components.scrollable;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyModifiers;
+
+class ScrollableTest {
+
+  static List<Element> rows(int count) {
+    List<Element> rs = new ArrayList<>();
+    for (int i = 0; i < count; i++) rs.add(length(1, text("row-" + i)));
+    return rs;
+  }
+
+  static String topLine(TestHarness h, int width) {
+    var buf = h.backend.buffer();
+    StringBuilder sb = new StringBuilder();
+    for (int x = 0; x < width; x++) sb.append(buf.cellAt(x, 0).symbol());
+    return sb.toString().trim();
+  }
+
+  @Test
+  void wheel_down_scrolls_content_by_step() throws IOException {
+    Element app = Scrollable.column(rows(30));
+    TestHarness h = new TestHarness(20, 10);
+    h.render(app);
+    assertTrue(topLine(h, 20).startsWith("row-0"));
+
+    h.renderer.dispatchMouse(
+        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.SCROLL_DOWN));
+    h.render(app);
+    assertTrue(topLine(h, 20).startsWith("row-" + Scrollable.STEP));
+  }
+
+  @Test
+  void wheel_up_clamps_at_zero() throws IOException {
+    Element app = Scrollable.column(rows(30));
+    TestHarness h = new TestHarness(20, 10);
+    h.render(app);
+
+    for (int i = 0; i < 5; i++) {
+      h.renderer.dispatchMouse(
+          new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.SCROLL_UP));
+      h.render(app);
+    }
+    assertTrue(topLine(h, 20).startsWith("row-0"), "wheel-up at offset 0 stays at 0");
+  }
+
+  /// Improved behavior over the typr original: max offset is clamped against the assigned
+  /// area's height. With 30 children and a 10-row viewport, max offset = 20 — wheel-down
+  /// can't push beyond row-20 at the top (which would mean row-29 at the bottom, exactly
+  /// aligned).
+  @Test
+  void wheel_down_clamps_at_max_so_last_child_stays_visible() throws IOException {
+    Element app = Scrollable.column(rows(30));
+    TestHarness h = new TestHarness(20, 10);
+    h.render(app);
+
+    // Scroll way down (10 ticks × STEP = 30, way past max=20).
+    for (int i = 0; i < 10; i++) {
+      h.renderer.dispatchMouse(
+          new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.SCROLL_DOWN));
+      h.render(app);
+    }
+
+    // Top should be row-20 (max offset for n=30, visibleH=10 = 30-10).
+    assertTrue(
+        topLine(h, 20).startsWith("row-20"),
+        "clamped at max offset; got top: '" + topLine(h, 20) + "'");
+  }
+
+  @Test
+  void no_overflow_no_scroll() throws IOException {
+    Element app = Scrollable.column(rows(5));
+    TestHarness h = new TestHarness(20, 10);
+    h.render(app);
+    // 5 children fit in 10-row viewport. max offset = max(0, 5-10) = 0. Wheel-down does nothing.
+    h.renderer.dispatchMouse(
+        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.SCROLL_DOWN));
+    h.render(app);
+    assertTrue(topLine(h, 20).startsWith("row-0"));
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/search/FuzzyMatchTest.java
+++ b/jatatui-tests/src/java/jatatui/components/search/FuzzyMatchTest.java
@@ -1,0 +1,93 @@
+package jatatui.components.search;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FuzzyMatchTest {
+
+  @Test
+  void word_starts_simple() {
+    assertEquals(java.util.Set.of(0), FuzzyMatch.wordStarts("hello"));
+    assertEquals(java.util.Set.of(0, 6), FuzzyMatch.wordStarts("hello world"));
+    assertEquals(java.util.Set.of(0, 6), FuzzyMatch.wordStarts("hello_world"));
+    assertEquals(java.util.Set.of(0, 6), FuzzyMatch.wordStarts("hello.world"));
+  }
+
+  @Test
+  void word_starts_camel_case() {
+    // h(0), W(5) — camel boundary between l and W
+    assertEquals(java.util.Set.of(0, 5), FuzzyMatch.wordStarts("helloWorld"));
+  }
+
+  @Test
+  void word_starts_letter_digit_boundary() {
+    // c(0), 1(3) — boundary letter→digit
+    assertEquals(java.util.Set.of(0, 3), FuzzyMatch.wordStarts("abc123"));
+    // 1(0), a(3) — boundary digit→letter
+    assertEquals(java.util.Set.of(0, 3), FuzzyMatch.wordStarts("123abc"));
+  }
+
+  @Test
+  void score_empty_query_is_negative_length_proxy() {
+    // Shorter strings should rank above longer for the empty query.
+    int shortS = FuzzyMatch.score("", "a").orElseThrow();
+    int longS = FuzzyMatch.score("", "aaaaaaaaaa").orElseThrow();
+    assertTrue(shortS > longS, "shorter target ranks higher for empty query");
+  }
+
+  @Test
+  void score_subsequence_required() {
+    assertTrue(FuzzyMatch.score("xyz", "hello").isEmpty());
+    assertTrue(FuzzyMatch.score("hel", "hello").isPresent());
+  }
+
+  @Test
+  void score_word_start_beats_in_word() {
+    // "cn" with word-start hits on each side ("customer_name") should score higher than
+    // "cu" with one word-start + one in-word hit ("customer").
+    int snake = FuzzyMatch.score("cn", "customer_name").orElseThrow();
+    int inWord = FuzzyMatch.score("cu", "customer").orElseThrow();
+    assertTrue(snake > inWord, "word-start hits on both chars > word-start + in-word");
+  }
+
+  @Test
+  void score_camel_word_start() {
+    int snake = FuzzyMatch.score("cn", "customer_name").orElseThrow();
+    int camel = FuzzyMatch.score("cn", "customerName").orElseThrow();
+    assertEquals(snake, camel, "snake and camel forms score the same");
+  }
+
+  @Test
+  void rank_filters_and_orders() {
+    List<String> items = List.of("customer_name", "customer_id", "order_total", "shipping_address");
+    var indexed = FuzzyMatch.index(items, s -> s);
+    List<String> ranked = FuzzyMatch.rank("cn", indexed);
+    assertTrue(ranked.contains("customer_name"));
+    assertEquals(
+        "customer_name",
+        ranked.get(0),
+        "highest-scoring (word-start on both chars) ranks first");
+    assertFalse(ranked.contains("order_total"), "non-matching items dropped");
+  }
+
+  @Test
+  void rank_empty_query_returns_all_in_original_order() {
+    List<String> items = List.of("zebra", "apple", "mango");
+    var indexed = FuzzyMatch.index(items, s -> s);
+    assertEquals(items, FuzzyMatch.rank("", indexed));
+  }
+
+  /// Hot-path API: scoreWith returns identical results to score for the same input — confirms
+  /// the precomputed-wordStarts shortcut doesn't drift from the convenience entry point.
+  @Test
+  void score_with_matches_score() {
+    String target = "customerName";
+    Optional<Integer> a = FuzzyMatch.score("cn", target);
+    Optional<Integer> b =
+        FuzzyMatch.scoreWith("cn", target, target.toLowerCase(), FuzzyMatch.wordStarts(target));
+    assertEquals(a, b);
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
+++ b/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
@@ -133,8 +133,44 @@ class SelectableListTest {
     assertEquals("a1", activated.get());
   }
 
+  /// Legacy single-click semantics, opted into via withActivateOnDoubleClick(false):
+  /// click on an unselected row selects it; click on the already-selected row activates.
   @Test
-  void click_on_unselected_row_selects_it_first() throws IOException {
+  void single_click_activate_legacy_behavior() throws IOException {
+    AtomicInteger activations = new AtomicInteger();
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = List.of(new Row.Item("a"), new Row.Item("b"), new Row.Item("c"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withOnActivate(r -> activations.incrementAndGet())
+                        .withActivateOnDoubleClick(false)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    // Click on row 2 (idx 2). Not currently selected → selects, no activation.
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(2, selectedIdx.get());
+    assertEquals(0, activations.get(), "click on unselected row selects, doesn't activate");
+
+    // Click again on the now-selected row → activates.
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(1, activations.get(), "click on already-selected row activates");
+  }
+
+  /// Default behavior: single-click selects only, double-click within 500ms activates.
+  @Test
+  void single_click_selects_double_click_activates() throws IOException {
     AtomicInteger activations = new AtomicInteger();
     AtomicInteger selectedIdx = new AtomicInteger(0);
     List<Row> rows = List.of(new Row.Item("a"), new Row.Item("b"), new Row.Item("c"));
@@ -153,16 +189,76 @@ class SelectableListTest {
     h.render(app);
     h.render(app);
 
-    // Click on row 2 (idx 2, "c"). Not currently selected → selects, no activation.
+    // Click on row 2 — selects only, no activation.
     h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
-    assertEquals(2, selectedIdx.get());
-    assertEquals(0, activations.get(), "click on unselected row selects, doesn't activate");
+    assertEquals(2, selectedIdx.get(), "click selects");
+    assertEquals(0, activations.get(), "no activation on single click");
 
-    // Click again on the now-selected row (still y=2) → activates.
+    // Click again on the same row within the double-click window → activates.
     h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
-    assertEquals(1, activations.get(), "click on already-selected row activates");
+    assertEquals(1, activations.get(), "double-click activates");
+  }
+
+  /// Two clicks on DIFFERENT rows don't constitute a double-click — second click selects only.
+  @Test
+  void clicks_on_different_rows_do_not_double_activate() throws IOException {
+    AtomicInteger activations = new AtomicInteger();
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = List.of(new Row.Item("a"), new Row.Item("b"), new Row.Item("c"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withOnActivate(r -> activations.incrementAndGet())
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    h.renderer.dispatchMouse(new MouseEvent(2, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    assertEquals(2, selectedIdx.get(), "selection moved to last clicked row");
+    assertEquals(0, activations.get(), "no activation — clicks were on different rows");
+  }
+
+  /// Two clicks too far apart in time don't constitute a double-click.
+  @Test
+  void second_click_after_double_click_window_does_not_activate() throws Exception {
+    AtomicInteger activations = new AtomicInteger();
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = List.of(new Row.Item("a"), new Row.Item("b"), new Row.Item("c"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withOnActivate(r -> activations.incrementAndGet())
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    Thread.sleep(600); // > DOUBLE_CLICK_MS (500)
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+
+    assertEquals(0, activations.get(), "second click outside double-click window does not activate");
   }
 
   @Test

--- a/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
+++ b/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
@@ -21,6 +21,7 @@ class SelectableListTest {
   /// Heterogeneous-row payload: Header for non-activatable decoration, Item for activatable rows.
   sealed interface Row {
     record Header(String title) implements Row {}
+
     record Item(String name) implements Row {}
   }
 
@@ -107,11 +108,7 @@ class SelectableListTest {
   void enter_activates_only_when_selected_is_activatable() throws IOException {
     AtomicReference<String> activated = new AtomicReference<>();
     AtomicInteger selectedIdx = new AtomicInteger(1); // Item
-    List<Row> rows =
-        List.of(
-            new Row.Header("Group"),
-            new Row.Item("a1"),
-            new Row.Item("a2"));
+    List<Row> rows = List.of(new Row.Header("Group"), new Row.Item("a1"), new Row.Item("a2"));
 
     Element app =
         component(
@@ -123,8 +120,7 @@ class SelectableListTest {
                             renderer(),
                             selectedIdx.get(),
                             selectedIdx::set)
-                        .withOnActivate(
-                            r -> activated.set(((Row.Item) r).name()))
+                        .withOnActivate(r -> activated.set(((Row.Item) r).name()))
                         .withFocusId("list")
                         .withAutoFocus(true)));
 
@@ -147,11 +143,7 @@ class SelectableListTest {
             ctx ->
                 jatatui.components.Components.selectableList(
                     SelectableListProps.of(
-                            rows,
-                            r -> true,
-                            renderer(),
-                            selectedIdx.get(),
-                            selectedIdx::set)
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
                         .withOnActivate(r -> activations.incrementAndGet())
                         .withFocusId("list")
                         .withAutoFocus(true)));
@@ -161,15 +153,13 @@ class SelectableListTest {
     h.render(app);
 
     // Click on row 2 (idx 2, "c"). Not currently selected → selects, no activation.
-    h.renderer.dispatchMouse(
-        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
     assertEquals(2, selectedIdx.get());
     assertEquals(0, activations.get(), "click on unselected row selects, doesn't activate");
 
     // Click again on the now-selected row (still y=2) → activates.
-    h.renderer.dispatchMouse(
-        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
     assertEquals(1, activations.get(), "click on already-selected row activates");
   }
@@ -199,8 +189,7 @@ class SelectableListTest {
     h.render(app);
 
     // Click on the header row (y=0).
-    h.renderer.dispatchMouse(
-        new MouseEvent(2, 0, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.renderer.dispatchMouse(new MouseEvent(2, 0, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
     assertEquals(1, selectedIdx.get(), "selection unchanged");
     assertEquals(0, activations.get(), "no activation");
@@ -217,11 +206,7 @@ class SelectableListTest {
             ctx ->
                 jatatui.components.Components.selectableList(
                     SelectableListProps.of(
-                            rows,
-                            r -> true,
-                            renderer(),
-                            selectedIdx.get(),
-                            selectedIdx::set)
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
                         .withFocusId("list")
                         .withAutoFocus(true)));
 
@@ -249,8 +234,113 @@ class SelectableListTest {
     StringBuilder topRowAfter = new StringBuilder();
     for (int x = 0; x < 12; x++) topRowAfter.append(buf.cellAt(x, 0).symbol());
     assertFalse(
-        topRowAfter.toString().startsWith("> item-0") || topRowAfter.toString().startsWith("  item-0"),
+        topRowAfter.toString().startsWith("> item-0")
+            || topRowAfter.toString().startsWith("  item-0"),
         "viewport scrolled past item-0; got '" + topRowAfter + "'");
+  }
+
+  @Test
+  void scrollbar_renders_in_rightmost_column_when_content_overflows() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 30; i++) rows.add(new Row.Item("i" + i));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    int w = 40;
+    int h = 10;
+    TestHarness harness = new TestHarness(w, h);
+    harness.render(app);
+    harness.render(app);
+
+    var buf = harness.backend.buffer();
+
+    // Rightmost column should contain scrollbar glyphs (track ║, thumb █, or arrows ▲ / ▼).
+    // We don't pin exact symbols-per-row — that's the scrollbar widget's responsibility — we
+    // just verify at least one scrollbar-shaped cell appears at x=w-1 across the viewport.
+    StringBuilder rightCol = new StringBuilder();
+    for (int y = 0; y < h; y++) rightCol.append(buf.cellAt(w - 1, y).symbol());
+
+    String trackOrThumbOrArrow = "║█▲▼";
+    boolean anyScrollbarCell = rightCol.chars().anyMatch(c -> trackOrThumbOrArrow.indexOf(c) >= 0);
+    assertTrue(
+        anyScrollbarCell,
+        "expected scrollbar glyph in rightmost column when content overflows; got '"
+            + rightCol
+            + "'");
+  }
+
+  @Test
+  void scrollbar_absent_when_show_scrollbar_disabled() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 30; i++) rows.add(new Row.Item("i" + i));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)
+                        .withShowScrollbar(false)));
+
+    int w = 40;
+    int h = 10;
+    TestHarness harness = new TestHarness(w, h);
+    harness.render(app);
+    harness.render(app);
+
+    var buf = harness.backend.buffer();
+    StringBuilder rightCol = new StringBuilder();
+    for (int y = 0; y < h; y++) rightCol.append(buf.cellAt(w - 1, y).symbol());
+
+    String trackOrThumbOrArrow = "║█▲▼";
+    boolean anyScrollbarCell = rightCol.chars().anyMatch(c -> trackOrThumbOrArrow.indexOf(c) >= 0);
+    assertFalse(
+        anyScrollbarCell,
+        "scrollbar should be absent when withShowScrollbar(false); got '" + rightCol + "'");
+  }
+
+  @Test
+  void scrollbar_absent_when_content_fits_viewport() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    // 5 rows in a 10-row viewport — no overflow.
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 5; i++) rows.add(new Row.Item("i" + i));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    int w = 40;
+    int h = 10;
+    TestHarness harness = new TestHarness(w, h);
+    harness.render(app);
+    harness.render(app);
+
+    var buf = harness.backend.buffer();
+    StringBuilder rightCol = new StringBuilder();
+    for (int y = 0; y < h; y++) rightCol.append(buf.cellAt(w - 1, y).symbol());
+
+    String trackOrThumbOrArrow = "║█▲▼";
+    boolean anyScrollbarCell = rightCol.chars().anyMatch(c -> trackOrThumbOrArrow.indexOf(c) >= 0);
+    assertFalse(
+        anyScrollbarCell,
+        "scrollbar should be hidden when content fits viewport; got '" + rightCol + "'");
   }
 
   @Test
@@ -264,11 +354,7 @@ class SelectableListTest {
             ctx ->
                 jatatui.components.Components.selectableList(
                     SelectableListProps.of(
-                            rows,
-                            r -> true,
-                            renderer(),
-                            selectedIdx.get(),
-                            selectedIdx::set)
+                            rows, r -> true, renderer(), selectedIdx.get(), selectedIdx::set)
                         .withFocusId("list")
                         .withAutoFocus(true)));
 

--- a/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
+++ b/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
@@ -3,6 +3,7 @@ package jatatui.components.selectablelist;
 import static jatatui.react.Components.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import jatatui.core.style.Color;
 import jatatui.core.style.Style;
 import jatatui.react.Element;
 import jatatui.react.KeyEvent;
@@ -374,5 +375,71 @@ class SelectableListTest {
     assertTrue(
         topRow.toString().contains("i16"),
         "viewport auto-scrolled so sel 25 is visible; top row should be i16, got '" + topRow + "'");
+  }
+
+  /// Regression: rows rendered via `text(content, style-with-magenta-fg)` used to bleed their fg
+  /// onto scrollbar cells because [jatatui.widgets.paragraph.Paragraph] calls
+  /// `buf.setStyle(area, style)` over the row's full width — including the rightmost cell. The
+  /// scrollbar's thumb writes its glyph with `Style.empty()`, which `Cell.setStyle` leaves the
+  /// existing fg in place for, so the thumb inherited the row's magenta and rendered as pink
+  /// dots in the scrollbar gutter.
+  ///
+  /// Fixed by reserving the rightmost column for the scrollbar via `row(fill, length)` so the
+  /// row layer never paints into the scrollbar's cells.
+  @Test
+  void scrollbar_does_not_inherit_row_fg_when_rows_are_styled() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 30; i++) rows.add(new Row.Item("i" + i));
+
+    Style magenta = Style.empty().withFg(new Color.Magenta());
+
+    SelectableListProps.RowRenderer<Row> magentaRenderer =
+        (row, sel) ->
+            switch (row) {
+              case Row.Header h -> text("== " + h.title() + " ==", magenta);
+              case Row.Item it -> text((sel ? "> " : "  ") + it.name(), magenta);
+            };
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> true,
+                            magentaRenderer,
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    int w = 40;
+    int h = 10;
+    TestHarness harness = new TestHarness(w, h);
+    harness.render(app);
+    harness.render(app);
+
+    var buf = harness.backend.buffer();
+
+    String trackOrThumbOrArrow = "║█▲▼";
+    int scrollbarCellsChecked = 0;
+    for (int y = 0; y < h; y++) {
+      var cell = buf.cellAt(w - 1, y);
+      String sym = cell.symbol();
+      if (sym.isEmpty() || trackOrThumbOrArrow.indexOf(sym.charAt(0)) < 0) continue;
+      scrollbarCellsChecked++;
+      assertNotEquals(
+          new Color.Magenta(),
+          cell.fg,
+          "scrollbar cell at y="
+              + y
+              + " (symbol '"
+              + sym
+              + "') inherited row fg magenta — row layer is bleeding into the scrollbar column");
+    }
+    assertTrue(
+        scrollbarCellsChecked > 0,
+        "expected at least one scrollbar glyph in the rightmost column to assert fg against");
   }
 }

--- a/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
+++ b/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
@@ -1,0 +1,292 @@
+package jatatui.components.selectablelist;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+import jatatui.react.KeyEvent;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyCode;
+import tui.crossterm.KeyModifiers;
+
+class SelectableListTest {
+
+  /// Heterogeneous-row payload: Header for non-activatable decoration, Item for activatable rows.
+  sealed interface Row {
+    record Header(String title) implements Row {}
+    record Item(String name) implements Row {}
+  }
+
+  static SelectableListProps.RowRenderer<Row> renderer() {
+    return (row, sel) ->
+        switch (row) {
+          case Row.Header h -> text("== " + h.title() + " ==", Style.empty());
+          case Row.Item it -> text((sel ? "> " : "  ") + it.name(), Style.empty());
+        };
+  }
+
+  @Test
+  void down_skips_non_activatable_rows() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(1); // start on first Item
+    List<Row> rows =
+        List.of(
+            new Row.Header("Group A"),
+            new Row.Item("a1"),
+            new Row.Item("a2"),
+            new Row.Header("Group B"),
+            new Row.Item("b1"));
+
+    Element appBound =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> r instanceof Row.Item,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(appBound);
+    h.render(appBound);
+
+    // Down from idx 1 (Item "a1") → idx 2 ("a2"), then skip header (idx 3) to idx 4 ("b1").
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Down(), new KeyModifiers(0)));
+    h.render(appBound);
+    assertEquals(2, selectedIdx.get(), "down moves to a2");
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Down(), new KeyModifiers(0)));
+    h.render(appBound);
+    assertEquals(4, selectedIdx.get(), "down skips header at idx 3, lands on b1");
+  }
+
+  @Test
+  void up_skips_non_activatable_rows() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(4); // last Item
+    List<Row> rows =
+        List.of(
+            new Row.Header("Group A"),
+            new Row.Item("a1"),
+            new Row.Item("a2"),
+            new Row.Header("Group B"),
+            new Row.Item("b1"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> r instanceof Row.Item,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Up(), new KeyModifiers(0)));
+    h.render(app);
+    assertEquals(2, selectedIdx.get(), "up from b1 (idx 4) skips header and lands on a2 (idx 2)");
+  }
+
+  @Test
+  void enter_activates_only_when_selected_is_activatable() throws IOException {
+    AtomicReference<String> activated = new AtomicReference<>();
+    AtomicInteger selectedIdx = new AtomicInteger(1); // Item
+    List<Row> rows =
+        List.of(
+            new Row.Header("Group"),
+            new Row.Item("a1"),
+            new Row.Item("a2"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> r instanceof Row.Item,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withOnActivate(
+                            r -> activated.set(((Row.Item) r).name()))
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    h.renderer.dispatchKey(new KeyEvent(new KeyCode.Enter(), new KeyModifiers(0)));
+    assertEquals("a1", activated.get());
+  }
+
+  @Test
+  void click_on_unselected_row_selects_it_first() throws IOException {
+    AtomicInteger activations = new AtomicInteger();
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = List.of(new Row.Item("a"), new Row.Item("b"), new Row.Item("c"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> true,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withOnActivate(r -> activations.incrementAndGet())
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    // Click on row 2 (idx 2, "c"). Not currently selected → selects, no activation.
+    h.renderer.dispatchMouse(
+        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(2, selectedIdx.get());
+    assertEquals(0, activations.get(), "click on unselected row selects, doesn't activate");
+
+    // Click again on the now-selected row (still y=2) → activates.
+    h.renderer.dispatchMouse(
+        new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(1, activations.get(), "click on already-selected row activates");
+  }
+
+  @Test
+  void click_on_non_activatable_row_is_noop() throws IOException {
+    AtomicInteger activations = new AtomicInteger();
+    AtomicInteger selectedIdx = new AtomicInteger(1); // start on the Item
+    List<Row> rows = List.of(new Row.Header("hdr"), new Row.Item("a"));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> r instanceof Row.Item,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withOnActivate(r -> activations.incrementAndGet())
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 20);
+    h.render(app);
+    h.render(app);
+
+    // Click on the header row (y=0).
+    h.renderer.dispatchMouse(
+        new MouseEvent(2, 0, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(1, selectedIdx.get(), "selection unchanged");
+    assertEquals(0, activations.get(), "no activation");
+  }
+
+  @Test
+  void wheel_scrolls_without_moving_selection() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 30; i++) rows.add(new Row.Item("item-" + i));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> true,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 10);
+    h.render(app);
+    h.render(app);
+
+    // Verify item-0 is currently visible at the top.
+    var buf = h.backend.buffer();
+    StringBuilder topRowBefore = new StringBuilder();
+    for (int x = 0; x < 12; x++) topRowBefore.append(buf.cellAt(x, 0).symbol());
+    assertTrue(topRowBefore.toString().contains("item-0"));
+
+    // Scroll wheel down a few times.
+    for (int i = 0; i < 3; i++) {
+      h.renderer.dispatchMouse(
+          new MouseEvent(2, 5, new KeyModifiers(0), MouseEvent.Kind.SCROLL_DOWN));
+      h.render(app);
+    }
+
+    // Selection should still be 0 (no movement on wheel).
+    assertEquals(0, selectedIdx.get(), "wheel doesn't move selection");
+
+    // The visible window has scrolled — item-0 no longer at top.
+    StringBuilder topRowAfter = new StringBuilder();
+    for (int x = 0; x < 12; x++) topRowAfter.append(buf.cellAt(x, 0).symbol());
+    assertFalse(
+        topRowAfter.toString().startsWith("> item-0") || topRowAfter.toString().startsWith("  item-0"),
+        "viewport scrolled past item-0; got '" + topRowAfter + "'");
+  }
+
+  @Test
+  void selection_change_auto_scrolls_into_view() throws IOException {
+    AtomicInteger selectedIdx = new AtomicInteger(0);
+    List<Row> rows = new java.util.ArrayList<>();
+    for (int i = 0; i < 30; i++) rows.add(new Row.Item("i" + i));
+
+    Element app =
+        component(
+            ctx ->
+                jatatui.components.Components.selectableList(
+                    SelectableListProps.of(
+                            rows,
+                            r -> true,
+                            renderer(),
+                            selectedIdx.get(),
+                            selectedIdx::set)
+                        .withFocusId("list")
+                        .withAutoFocus(true)));
+
+    TestHarness h = new TestHarness(40, 10);
+    h.render(app);
+    h.render(app);
+
+    // Jump selection programmatically to row 25 (way out of the 0..9 viewport).
+    selectedIdx.set(25);
+    h.render(app);
+
+    // Auto-scroll: selected (25) should be visible. Viewport size = 10 → offset = 25-10+1 = 16.
+    // Last visible row = 25 (selected). Top visible = 16.
+    var buf = h.backend.buffer();
+    StringBuilder topRow = new StringBuilder();
+    for (int x = 0; x < 6; x++) topRow.append(buf.cellAt(x, 0).symbol());
+    assertTrue(
+        topRow.toString().contains("i16"),
+        "viewport auto-scrolled so sel 25 is visible; top row should be i16, got '" + topRow + "'");
+  }
+}

--- a/jatatui-tests/src/java/jatatui/components/textinput/TextInputClickToFocusTest.java
+++ b/jatatui-tests/src/java/jatatui/components/textinput/TextInputClickToFocusTest.java
@@ -1,0 +1,107 @@
+package jatatui.components.textinput;
+
+import static jatatui.components.Components.titledTextInput;
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import jatatui.core.layout.Margin;
+import jatatui.react.Element;
+import jatatui.react.MouseEvent;
+import jatatui.react.TestHarness;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tui.crossterm.KeyModifiers;
+
+/// Click-to-focus on TextInputComponent. Two titled inputs in a column; clicking the second
+/// transfers focus from the first.
+class TextInputClickToFocusTest {
+
+  @Test
+  void click_focuses_input() throws IOException {
+    TestHarness h = new TestHarness(60, 12);
+
+    List<String> values = new ArrayList<>(List.of("", ""));
+    List<Boolean> focusFlags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx ->
+                column(
+                        length(3, namedField(ctx, focusFlags, values, 0, "alpha")),
+                        length(3, namedField(ctx, focusFlags, values, 1, "beta")),
+                        fill(1, text("")))
+                    .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0))));
+
+    h.render(app);
+    h.render(app);
+    // Clear and read fresh — render invokes the inner components which mutate focusFlags.
+    focusFlags.clear();
+    h.render(app);
+    assertEquals(List.of(true, false), focusFlags, "first input is auto-focused");
+
+    // Click in the second input's area (rows 3..5 of the column).
+    h.events.dispatchMouse(
+        new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    focusFlags.clear();
+    h.render(app);
+    assertEquals(List.of(false, true), focusFlags, "click on input b transfers focus");
+  }
+
+  /// `withFocusOnClick(false)` opts out: clicking the input does NOT focus it.
+  @Test
+  void focus_on_click_can_be_disabled() throws IOException {
+    TestHarness h = new TestHarness(60, 12);
+
+    List<String> values = new ArrayList<>(List.of("", ""));
+    List<Boolean> focusFlags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx ->
+                column(
+                        length(3, namedField(ctx, focusFlags, values, 0, "alpha")),
+                        length(3, namedFieldNoClick(ctx, focusFlags, values, 1, "beta")),
+                        fill(1, text("")))
+                    .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0))));
+
+    h.render(app);
+    h.render(app);
+    focusFlags.clear();
+    h.render(app);
+    assertEquals(List.of(true, false), focusFlags);
+
+    h.events.dispatchMouse(
+        new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    focusFlags.clear();
+    h.render(app);
+    assertEquals(List.of(true, false), focusFlags, "focus stays on first when click-to-focus is disabled");
+  }
+
+  static Element namedField(
+      jatatui.react.RenderContext outerCtx, List<Boolean> flags, List<String> values, int idx, String id) {
+    return component(
+        ctx -> {
+          flags.add(ctx.useFocus(java.util.Optional.of(id), idx == 0));
+          int captured = idx;
+          return titledTextInput(id, values.get(captured), v -> values.set(captured, v), id, id);
+        });
+  }
+
+  static Element namedFieldNoClick(
+      jatatui.react.RenderContext outerCtx, List<Boolean> flags, List<String> values, int idx, String id) {
+    return component(
+        ctx -> {
+          flags.add(ctx.useFocus(java.util.Optional.of(id), idx == 0));
+          int captured = idx;
+          return jatatui.components.Components.textInput(
+              jatatui.components.textinput.TextInputProps.of(
+                      values.get(captured), v -> values.set(captured, v))
+                  .withTitle(id)
+                  .withFocusId(id)
+                  .withAutoFocus(false)
+                  .withFocusOnClick(false));
+        });
+  }
+}

--- a/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
@@ -1,0 +1,104 @@
+package jatatui.react;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ImperativeFocusTest {
+
+  /// `ctx.focus(id)` from inside a render body changes which focusable is focused on the next
+  /// render. (Mirrors the real-world pattern: a click handler / validation callback / list-row
+  /// selector imperatively focuses something specific.)
+  @Test
+  void focus_id_takes_effect_next_render() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+
+    AtomicReference<RenderContext> ctxRef = new AtomicReference<>();
+    List<Boolean> flags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx -> {
+              ctxRef.set(ctx);
+              flags.clear();
+              flags.add(ctx.useFocus(Optional.of("a"), true));
+              flags.add(ctx.useFocus(Optional.of("b"), false));
+              flags.add(ctx.useFocus(Optional.of("c"), false));
+              return text("3 focusables");
+            });
+
+    // Two renders: first registers, second sees autoFocus committed.
+    h.render(app);
+    h.render(app);
+    assertEquals(List.of(true, false, false), flags);
+
+    // Imperatively focus "c".
+    ctxRef.get().focus("c");
+    h.render(app);
+    assertEquals(List.of(false, false, true), flags);
+
+    // Imperatively focus "b".
+    ctxRef.get().focus("b");
+    h.render(app);
+    assertEquals(List.of(false, true, false), flags);
+  }
+
+  @Test
+  void blur_clears_focus() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    AtomicReference<RenderContext> ctxRef = new AtomicReference<>();
+    List<Boolean> flags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx -> {
+              ctxRef.set(ctx);
+              flags.clear();
+              flags.add(ctx.useFocus(Optional.of("a"), true));
+              return text("one");
+            });
+
+    h.render(app);
+    h.render(app);
+    assertEquals(List.of(true), flags);
+
+    ctxRef.get().blur();
+    h.render(app);
+    assertEquals(List.of(false), flags, "blur clears focus; nothing focused next render");
+  }
+
+  /// `ctx.focus(id)` from a click handler — the canonical "click to focus" pattern.
+  @Test
+  void click_handler_can_focus_other_field() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+
+    List<Boolean> flags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx -> {
+              flags.clear();
+              flags.add(ctx.useFocus(Optional.of("a"), true));
+              boolean bFocused = ctx.useFocus(Optional.of("b"), false);
+              flags.add(bFocused);
+              ctx.onClick(e -> ctx.focus("b"));
+              return text("clickable-area");
+            });
+
+    h.render(app);
+    h.render(app);
+    assertEquals(List.of(true, false), flags);
+
+    // Click anywhere — handler calls ctx.focus("b").
+    h.events.dispatchMouse(
+        new MouseEvent(2, 0, new tui.crossterm.KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.render(app);
+    assertEquals(List.of(false, true), flags);
+  }
+}

--- a/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
@@ -49,8 +49,11 @@ class ImperativeFocusTest {
     assertEquals(List.of(false, true, false), flags);
   }
 
+  /// `blur()` is transient — it drops the current focus, but the next render's autoFocus
+  /// candidate (if any) reclaims same-frame thanks to eager-claim. Without an autoFocus
+  /// candidate, nothing reclaims and the field stays unfocused.
   @Test
-  void blur_clears_focus() throws IOException {
+  void blur_clears_focus_until_next_autofocus_claim() throws IOException {
     TestHarness h = new TestHarness(40, 12);
     AtomicReference<RenderContext> ctxRef = new AtomicReference<>();
     List<Boolean> flags = new ArrayList<>();
@@ -60,17 +63,80 @@ class ImperativeFocusTest {
             ctx -> {
               ctxRef.set(ctx);
               flags.clear();
-              flags.add(ctx.useFocus(Optional.of("a"), true));
+              // autoFocus=false — nothing should reclaim after blur.
+              flags.add(ctx.useFocus(Optional.of("a"), false));
               return text("one");
             });
 
+    // Force-focus "a" first so it's the active focus.
     h.render(app);
+    ctxRef.get().focus("a");
     h.render(app);
     assertEquals(List.of(true), flags);
 
     ctxRef.get().blur();
     h.render(app);
-    assertEquals(List.of(false), flags, "blur clears focus; nothing focused next render");
+    assertEquals(List.of(false), flags, "blur clears focus and nothing reclaims");
+  }
+
+  /// First-frame autoFocus: the eager-claim in FocusManager.register makes useFocus return
+  /// true on the SAME frame as the autoFocus registration — no need for a second render pass
+  /// to make the focused element visible.
+  @Test
+  void auto_focus_visible_on_first_frame() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    List<Boolean> flags = new ArrayList<>();
+
+    Element app =
+        component(
+            ctx -> {
+              flags.clear();
+              flags.add(ctx.useFocus(Optional.of("a"), true));
+              flags.add(ctx.useFocus(Optional.of("b"), false));
+              flags.add(ctx.useFocus(Optional.of("c"), false));
+              return text("3 focusables");
+            });
+
+    h.render(app);
+    assertEquals(
+        List.of(true, false, false),
+        flags,
+        "first autoFocus is focused on the SAME frame; no second render needed");
+  }
+
+  /// Screen-change case: when the previously focused id isn't re-registered (e.g. router
+  /// pushes a different screen), commit picks a new winner AFTER render, so the first paint of
+  /// the new screen shows nothing focused. Renderer requests a re-render so the host's next
+  /// loop tick paints with the new focus visible.
+  @Test
+  void screen_change_requests_rerender_so_new_focus_paints_next_tick() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+
+    Element screenA = component(ctx -> {
+      ctx.useFocus(Optional.of("A"), true);
+      return text("A");
+    });
+    Element screenB = component(ctx -> {
+      ctx.useFocus(Optional.of("B"), true);
+      return text("B");
+    });
+
+    java.util.concurrent.atomic.AtomicBoolean showA =
+        new java.util.concurrent.atomic.AtomicBoolean(true);
+    Element wrapper = component(ctx -> showA.get() ? screenA : screenB);
+
+    h.render(wrapper);
+    h.renderer.clearDirty();
+    assertEquals(Optional.of("A"), h.focus.currentlyFocused());
+
+    // Swap to screen B. focused still points at "A" going INTO this render. B registers; the
+    // eager-claim only fires when focused.isEmpty(), so it doesn't fire here. After commit,
+    // "A" is no longer registered → commit picks "B". Renderer notices the change and flips
+    // dirty — host's next iteration re-renders with focus visible.
+    showA.set(false);
+    h.render(wrapper);
+    assertTrue(h.renderer.isDirty(), "commit changed focus → request re-render");
+    assertEquals(Optional.of("B"), h.focus.currentlyFocused());
   }
 
   /// `ctx.focus(id)` from a click handler — the canonical "click to focus" pattern.

--- a/jatatui-tests/src/java/jatatui/react/ReconciliationTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ReconciliationTest.java
@@ -1,0 +1,155 @@
+package jatatui.react;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/// When the Element type at a fiber position changes between frames, the old subtree is
+/// unmounted (state dropped, cleanups run) before the new one renders. This is what React
+/// calls "reconciliation" — the rule that prevents the stack-router bug where SourceEditor
+/// and OutputEditor share a fiber slot and one's useState supplier never re-runs because the
+/// other's state still occupies the slot.
+class ReconciliationTest {
+
+  /// The canonical bug repro: two screens with different state types at the same fiber slot.
+  /// Without reconciliation, screen B's useState returns screen A's stored value (CCE in
+  /// strongly-typed code). With reconciliation, screen B's initializer runs fresh.
+  @Test
+  void state_resets_when_component_changes_at_same_fiber() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    AtomicReference<Object> seen = new AtomicReference<>();
+
+    Element screenA =
+        component(
+            ctx -> {
+              State<Integer> s = ctx.useState(() -> 42);
+              seen.set(s.get());
+              return text("A");
+            });
+    Element screenB =
+        component(
+            ctx -> {
+              State<String> s = ctx.useState(() -> "hello");
+              seen.set(s.get());
+              return text("B");
+            });
+
+    AtomicBoolean showA = new AtomicBoolean(true);
+    Element wrapper = component(ctx -> showA.get() ? screenA : screenB);
+
+    h.render(wrapper);
+    assertEquals(42, seen.get());
+
+    h.render(wrapper); // stable
+    assertEquals(42, seen.get());
+
+    showA.set(false);
+    h.render(wrapper);
+    assertEquals(
+        "hello", seen.get(), "different component at same fiber → fresh useState initial");
+
+    showA.set(true);
+    h.render(wrapper);
+    assertEquals(42, seen.get(), "swap back → A's state freshly initialized again");
+  }
+
+  /// Cleanups for the unmounted subtree run BEFORE the new component renders.
+  @Test
+  void unmount_runs_cleanups_for_old_subtree() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    AtomicInteger cleanupCount = new AtomicInteger();
+
+    Element withCleanup =
+        component(
+            ctx -> {
+              ctx.useState(() -> 1);
+              // Hand-place a cleanup keyed on the same fiber + an unused hook slot so unmount
+              // exercises its cleanup-execution branch without depending on useEffect timing
+              // semantics.
+              h.hooks.cleanups.put(new HookKey(ctx.fiber, 99), cleanupCount::incrementAndGet);
+              return text("with-cleanup");
+            });
+    Element other = component(ctx -> text("other"));
+
+    AtomicBoolean showCleanup = new AtomicBoolean(true);
+    Element wrapper = component(ctx -> showCleanup.get() ? withCleanup : other);
+
+    h.render(wrapper);
+    h.render(wrapper);
+    assertEquals(0, cleanupCount.get(), "no swap yet, no unmount");
+
+    showCleanup.set(false);
+    h.render(wrapper);
+    assertEquals(1, cleanupCount.get(), "swap → unmount → cleanup runs");
+  }
+
+  /// Same component at same fiber across renders → state is reused (no spurious unmount).
+  @Test
+  void state_persists_when_same_component_re_renders() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    AtomicReference<State<Integer>> stateRef = new AtomicReference<>();
+
+    Element app =
+        component(
+            ctx -> {
+              State<Integer> s = ctx.useState(() -> 0);
+              stateRef.set(s);
+              return text("count = " + s.get());
+            });
+
+    h.render(app);
+    stateRef.get().set(7);
+    h.render(app);
+    assertEquals(7, stateRef.get().get(), "same component, state reused");
+
+    h.render(app);
+    h.render(app);
+    assertEquals(7, stateRef.get().get(), "still 7 after more renders");
+  }
+
+  /// `apply(STABLE_COMPONENT, props)` form — different stable Component instances at the same
+  /// fiber slot trigger reconciliation just like FUNCTION lambdas do.
+  @Test
+  void state_resets_for_apply_with_distinct_components() throws IOException {
+    TestHarness h = new TestHarness(40, 12);
+    AtomicReference<Object> seen = new AtomicReference<>();
+
+    Component<Integer> compA =
+        (props, ctx) ->
+            text(
+                "A:"
+                    + (Integer) ctx.useState(() -> {
+                      seen.set("A-init");
+                      return props * 10;
+                    }).get());
+    Component<Integer> compB =
+        (props, ctx) ->
+            text(
+                "B:"
+                    + (Integer) ctx.useState(() -> {
+                      seen.set("B-init");
+                      return props + 100;
+                    }).get());
+
+    AtomicBoolean useA = new AtomicBoolean(true);
+    Element wrapper = component(ctx -> useA.get() ? apply(compA, 5) : apply(compB, 7));
+
+    h.render(wrapper);
+    assertEquals("A-init", seen.get());
+
+    h.render(wrapper);
+    // re-render of A: initializer NOT called again
+    seen.set("(unchanged)");
+    h.render(wrapper);
+    assertEquals("(unchanged)", seen.get(), "same Component, state reused");
+
+    useA.set(false);
+    h.render(wrapper);
+    assertEquals("B-init", seen.get(), "different Component, fresh state");
+  }
+}

--- a/jatatui-tests/src/java/jatatui/react/UseTimeoutTest.java
+++ b/jatatui-tests/src/java/jatatui/react/UseTimeoutTest.java
@@ -1,0 +1,127 @@
+package jatatui.react;
+
+import static jatatui.react.Components.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class UseTimeoutTest {
+
+  /// Mount, render before delay elapses, callback hasn't fired. Sleep past delay, render
+  /// again, callback fires on the render thread.
+  @Test
+  void fires_once_after_delay_on_render_thread() throws Exception {
+    AtomicInteger fireCount = new AtomicInteger();
+    AtomicReferenceLong fireThreadId = new AtomicReferenceLong();
+
+    Element app =
+        component(
+            ctx -> {
+              ctx.useTimeout(
+                  60,
+                  () -> {
+                    fireCount.incrementAndGet();
+                    fireThreadId.set(Thread.currentThread().getId());
+                  });
+              return text("");
+            });
+
+    TestHarness h = new TestHarness(20, 5);
+    long renderThreadId = Thread.currentThread().getId();
+
+    h.render(app);
+    assertEquals(0, fireCount.get(), "render before delay → no fire");
+
+    Thread.sleep(120);
+    h.render(app);
+    assertEquals(1, fireCount.get(), "render after delay → cb fires once");
+
+    // Re-rendering after fire does not re-fire.
+    h.render(app);
+    h.render(app);
+    assertEquals(1, fireCount.get(), "subsequent renders → no re-fire");
+
+    assertEquals(renderThreadId, fireThreadId.get(), "cb runs on the render thread");
+  }
+
+  /// Unmount before delay elapses → cleanup cancels the schedule → callback never runs.
+  @Test
+  void unmount_before_delay_cancels_callback() throws Exception {
+    AtomicBoolean fired = new AtomicBoolean();
+    AtomicBoolean show = new AtomicBoolean(true);
+
+    Element child =
+        component(
+            ctx -> {
+              ctx.useTimeout(80, () -> fired.set(true));
+              return text("inside");
+            });
+
+    Element wrapper = component(ctx -> show.get() ? child : text("(unmounted)"));
+
+    TestHarness h = new TestHarness(20, 5);
+    h.render(wrapper);
+    assertFalse(fired.get());
+
+    // Unmount: hook sweep runs cleanup which cancels the scheduled future.
+    show.set(false);
+    h.render(wrapper);
+
+    // Wait well past the original delay; even if the scheduler still fires its requestRerender
+    // (cancel might race), the callback only runs when useTimeout is invoked during the
+    // unmounted component's render — which doesn't happen anymore.
+    Thread.sleep(150);
+    h.render(wrapper);
+    assertFalse(fired.get(), "callback must not run after unmount");
+  }
+
+  /// Deps change cancels the previous timer and re-arms with a fresh delay.
+  @Test
+  void deps_change_resets_the_timer() throws Exception {
+    AtomicInteger fireCount = new AtomicInteger();
+    AtomicInteger deps = new AtomicInteger(1);
+
+    Element app =
+        component(
+            ctx -> {
+              ctx.useTimeout(80, fireCount::incrementAndGet, deps.get());
+              return text("");
+            });
+
+    TestHarness h = new TestHarness(20, 5);
+    h.render(app);
+
+    // Wait nearly the whole delay, then bump deps. The first timer should be cancelled.
+    Thread.sleep(50);
+    deps.set(2);
+    h.render(app);
+
+    // Wait the remaining 30ms of the original delay — should NOT fire because the new timer
+    // restarted from this point.
+    Thread.sleep(40);
+    h.render(app);
+    assertEquals(0, fireCount.get(), "first timer was cancelled when deps changed");
+
+    // Now wait past the second timer's full 80ms (we already slept 40 of the new period).
+    Thread.sleep(60);
+    h.render(app);
+    assertEquals(1, fireCount.get(), "second timer fired");
+  }
+
+  /// Convenience: java.util.concurrent.atomic.AtomicLong with a `getId` semantic.
+  static final class AtomicReferenceLong {
+    private final java.util.concurrent.atomic.AtomicLong v =
+        new java.util.concurrent.atomic.AtomicLong(-1);
+
+    long get() {
+      return v.get();
+    }
+
+    void set(long val) {
+      v.set(val);
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,13 @@ the upstream `examples/apps/*`) and the React-style demos in
 
 ## React-style layer (optional)
 
+> [!WARNING]
+> **`jatatui-react` and `jatatui-components` are proof-of-concept.** They've
+> been used to build a real app (typr), and the core ideas are working, but
+> sweeping API changes are likely as the layer matures. Pin a specific
+> snapshot if you're depending on it for production code, and expect to
+> refactor on each minor version bump.
+
 `jatatui-react` and `jatatui-components` add a React-shaped API: components as
 pure functions, hooks for state, event bubbling, focus management. Same buffer
 underneath — just different ergonomics.


### PR DESCRIPTION
## So what's this

The React-ish layer in `jatatui-react` is now working well enough to drive a real app end-to-end — a multi-screen TUI config editor. Components, hooks, focus, event bubbling, portals, reconciliation: all behaving. We're not just shipping a prototype anymore — there's a real consumer driving real bug reports, and the layer is responding to them gracefully.

That's the good news. The honest caveat: this is still **proof-of-concept code**. The patterns that have proven out (Renderer as host-friendly engine, controlled selection, generic `T` everywhere, fiber-keyed hook reconciliation) are stable enough to merge. But the surface is small and expect more sweeping changes as the layer keeps shaking out real-world wrinkles. There's now a callout to that effect at the top of the React section in the readme.

## What this looks like in code

A two-screen app with a router, a focusable button, an autofocused field, and a confirmation modal — covering most of the new layer at once:

```java
import static jatatui.components.Components.*;
import static jatatui.react.Components.*;

import jatatui.components.router.RouterApi;
import jatatui.components.router.Screen;
import jatatui.react.Element;
import jatatui.react.ReactApp;
import java.util.Optional;

public final class Demo {
  public static void main(String[] args) throws java.io.IOException {
    ReactApp.run(router(Screen.of("home", home())));
  }

  static Element home() {
    return component(ctx -> {
      var router = RouterApi.useRouter(ctx);
      return screenFrame("quit", () -> System.exit(0),
          column(
              length(1, text(" Welcome ")),
              length(3, button("Add source", "add", true,
                  () -> router.push("add-source", addSource()))),
              fill(1, empty())));
    });
  }

  static Element addSource() {
    return component(ctx -> {
      var name           = ctx.useState(() -> "");
      var confirmCancel  = ctx.useState(() -> false);
      var router         = RouterApi.useRouter(ctx);

      return screenFrame("back", () -> confirmCancel.set(true),
          column(
              length(1, text(" Add source ")),
              length(3, titledTextInput("Name", name.get(), name::set, "my-db", "name")),
              fill(1, empty()),
              length(3, button("Save", "save", true, () -> {
                  // ... persist name.get() ...
                  router.pop();
              })),

              confirmDialog(
                  confirmCancel.get(),
                  " Discard? ",
                  "Throw away unsaved changes?",
                  "Discard", "Keep editing", true,
                  () -> { confirmCancel.set(false); router.pop(); },
                  () -> confirmCancel.set(false))));
    });
  }
}
```

Reads roughly like a React/Ink app. `ctx.useState`, focusable `button(...)`, `titledTextInput(...)` with controlled value + onChange, `confirmDialog(...)` driven by a state flag. The router is a Context-provided service descendants pull via `RouterApi.useRouter(ctx)`. Tab cycles focus across the focusables; Enter activates buttons; Esc on the back chip pops the stack.

## What changed

### `jatatui-react` core

- **Reconciliation** — drop hook state when the component type at a fiber slot changes. Fixes the canonical router-state-bleed bug where `useState` would return a previous screen's value when the router swapped a different screen into the same fiber slot. Uses lambda class identity so it works even for inline `component(c -> ...)` functions.
- **Eager autoFocus + post-commit rerender** — `FocusManager.register` claims focus same-frame when nothing else holds it; `Renderer.render` requests a rerender if `commit()` chose a new winner. No more two-frame flicker on first render or after blur.
- **Imperative focus** — `ctx.focus(id)` / `ctx.blur()`. `TextInputComponent` registers click-to-focus by default.
- **`useTimeout(delayMs, callback, deps...)`** — fires once on the render thread; single shared daemon scheduler; auto-cleanup on unmount; deps follow `useEffect` convention.
- **EventRegistry**: `globalKeys` phase honors `Predicate` matchers (was identity-equals, silently dropping `ANY_KEY`).

### `jatatui-components` revisions

- **Router** clears focus on every stack transition — new screen's autoFocus claims same-frame.
- **Dropdown** got the full treatment: clickable rows, working keys (handlers moved to the dropdown's own fiber so they sit in the focused bubble chain), auto-close on focus loss, opaque overlay (`Clear` under the list), Tab-while-open commits the current highlight, **now generic over option type** with a `labelFn` (was stringly-typed; matches Picker/SelectableList/ListProps/TableProps).
- **Modal**: replaced `(int width, int height)` with `Size`, matching Picker. Backwards-compat helper preserves the old signature.

### New components in `jatatui-components`

- **`picker.Picker`** — Quick-Pick / Go-To-Symbol search modal. Host-supplied `Filter<T>` and `RowRenderer<T>`. Forcibly claims focus on mount so keystrokes don't leak to host handlers.
- **`selectablelist.SelectableList`** — Heterogeneous-row list. `Predicate<T> isActivatable` lets headers / dividers / decorative rows coexist with selectable rows; Up/Down skips non-activatable, click activates only activatable. Auto-scroll gated on selection change so wheel scrolls aren't reverted. Default double-click to activate (legacy single-click-activate via `withActivateOnDoubleClick(false)`). Vertical scrollbar in the rightmost column on overflow.
- **`button.Button`** — Bordered, Tab-focusable, Enter + click activate, primary/secondary variants.
- **`chrome.BackButton` + `chrome.ScreenFrame`** — Standard \"← label\" chip + the top-of-screen layout that uses it. Blurs focus on back so the destination's autoFocus claims same-frame.
- **`modal.ConfirmDialog`** — Yes/No modal with `danger` variant, built on `Modal`.
- **`link.Link`** — Focusable + clickable + Enter-activatable. Router-agnostic via `Runnable onActivate`.
- **`search.FuzzyMatch`** — IntelliJ-style fuzzy scoring with word-boundary bonus. Algorithm only, plugs into `PickerProps.Filter`. Includes `Indexed<A>` for precomputed corpora and `rank()` for filter+sort.
- **`scrollable.Scrollable`** — Wheel-scrollable column with proper max-offset clamping against the assigned area height.

## Test plan

- [x] `bleep test jatatui-tests` — 2044 tests green
- [x] `bleep publish local-ivy` — `0.30.0+15-e582d175` consumed by the downstream app without errors
- [x] All public-API renames have source-compat helpers (`Modal.withSize(int, int)`, `DropdownProps.ofStrings`)
- [x] Readme PoC warning callout added on the React section

🤖 Generated with [Claude Code](https://claude.com/claude-code)