### PR TITLE
Run bleep fmt over the repo, and gate it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Compile + test
+    name: Format + compile + test
     timeout-minutes: 15
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
@@ -20,6 +20,20 @@ jobs:
       - uses: coursier/cache-action@v7
         with:
           extraFiles: bleep.yaml
+
+      # The `bleep` launcher reads $version from bleep.yaml, so this checks with exactly the
+      # scalafmt and google-java-format versions a contributor running `bleep fmt` gets. A gate
+      # formatting with a different version than contributors do is worse than no gate.
+      - name: Check formatting
+        run: bleep fmt --check
+
+      # `--check` names the offending files but not what is wrong with them. Reformat and print
+      # the diff so the failure says exactly which lines to change.
+      - name: Show formatting diff
+        if: failure()
+        run: |
+          bleep fmt
+          git --no-pager diff
 
       - name: Compile
         run: bleep compile

--- a/jatatui-components/src/java/jatatui/components/Components.java
+++ b/jatatui-components/src/java/jatatui/components/Components.java
@@ -1,35 +1,35 @@
 package jatatui.components;
 
+import jatatui.components.button.Button;
+import jatatui.components.chrome.BackButton;
+import jatatui.components.chrome.ScreenFrame;
+import jatatui.components.dropdown.Dropdown;
+import jatatui.components.dropdown.DropdownProps;
+import jatatui.components.form.FormProvider;
 import jatatui.components.gauge.GaugeComponent;
 import jatatui.components.gauge.GaugeProps;
 import jatatui.components.gauge.LineGaugeComponent;
 import jatatui.components.gauge.LineGaugeProps;
+import jatatui.components.link.Link;
 import jatatui.components.list.ListComponent;
 import jatatui.components.list.ListProps;
-import jatatui.components.dropdown.Dropdown;
-import jatatui.components.dropdown.DropdownProps;
-import jatatui.components.form.FormProvider;
-import jatatui.components.button.Button;
-import jatatui.components.chrome.BackButton;
-import jatatui.components.chrome.ScreenFrame;
-import jatatui.components.link.Link;
 import jatatui.components.modal.ConfirmDialog;
 import jatatui.components.modal.Modal;
 import jatatui.components.modal.ModalProps;
-import jatatui.components.scrollable.Scrollable;
 import jatatui.components.picker.Picker;
 import jatatui.components.picker.PickerProps;
-import jatatui.components.selectablelist.SelectableList;
-import jatatui.components.selectablelist.SelectableListProps;
 import jatatui.components.router.Router;
 import jatatui.components.router.Screen;
-import jatatui.components.theme.Theme;
-import jatatui.components.theme.ThemeProvider;
-import jatatui.components.toast.ToastsProvider;
+import jatatui.components.scrollable.Scrollable;
+import jatatui.components.selectablelist.SelectableList;
+import jatatui.components.selectablelist.SelectableListProps;
 import jatatui.components.table.Table;
 import jatatui.components.table.TableProps;
 import jatatui.components.textinput.TextInputComponent;
 import jatatui.components.textinput.TextInputProps;
+import jatatui.components.theme.Theme;
+import jatatui.components.theme.ThemeProvider;
+import jatatui.components.toast.ToastsProvider;
 import jatatui.core.layout.Constraint;
 import jatatui.core.style.Style;
 import jatatui.react.Element;
@@ -269,7 +269,9 @@ public final class Components {
   /// Focusable + clickable activation target. `onActivate` runs on Enter (when focused) or on
   /// click. The most common use is `() -> router.push(screen)`, but any Runnable works.
   public static Element link(
-      boolean autoFocus, Runnable onActivate, java.util.function.Function<Boolean, Element> content) {
+      boolean autoFocus,
+      Runnable onActivate,
+      java.util.function.Function<Boolean, Element> content) {
     return Link.focusable(autoFocus, onActivate, content);
   }
 

--- a/jatatui-components/src/java/jatatui/components/chrome/BackButton.java
+++ b/jatatui-components/src/java/jatatui/components/chrome/BackButton.java
@@ -41,8 +41,7 @@ public final class BackButton {
               .ifPresent(
                   a -> {
                     int width = Math.min(buttonWidth, a.width());
-                    Rect hit =
-                        new Rect(a.x(), a.y(), width, Math.min(HEIGHT, a.height()));
+                    Rect hit = new Rect(a.x(), a.y(), width, Math.min(HEIGHT, a.height()));
                     ctx.onClick(
                         hit,
                         e -> {

--- a/jatatui-components/src/java/jatatui/components/chrome/ScreenFrame.java
+++ b/jatatui-components/src/java/jatatui/components/chrome/ScreenFrame.java
@@ -23,8 +23,7 @@ public final class ScreenFrame {
 
   /// Variant with a brand/title strip next to the back button (e.g. main-menu header). The
   /// back chip is fixed-width on the left; the title fills the remainder.
-  public static Element withTitle(
-      String backLabel, Runnable back, Element title, Element content) {
+  public static Element withTitle(String backLabel, Runnable back, Element title, Element content) {
     return component(
         ctx ->
             column(

--- a/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
+++ b/jatatui-components/src/java/jatatui/components/dropdown/Dropdown.java
@@ -131,7 +131,8 @@ public final class Dropdown {
                     // this, underlying widgets' borders / text bleed through gaps in our rows.
                     return stack(
                         widget(jatatui.widgets.Clear.instance()),
-                        optionsList(props.items(), props.labelFn(), hi, props.onChange(), openState));
+                        optionsList(
+                            props.items(), props.labelFn(), hi, props.onChange(), openState));
                   });
 
           Element backdrop =
@@ -162,7 +163,10 @@ public final class Dropdown {
       boolean hi = i == highlightedIndex;
       Style rowStyle =
           hi
-              ? Style.empty().withBg(new Color.Blue()).withFg(new Color.White()).withAddModifier(Modifier.BOLD)
+              ? Style.empty()
+                  .withBg(new Color.Blue())
+                  .withFg(new Color.White())
+                  .withAddModifier(Modifier.BOLD)
               : Style.empty();
       String prefix = hi ? "> " : "  ";
       int idx = i;
@@ -184,7 +188,8 @@ public final class Dropdown {
 
   private static Rect listAreaBelow(Rect anchor, int itemCount, Rect screen) {
     int width = anchor.width();
-    int height = Math.min(itemCount + 2, screen.height() - (anchor.y() + anchor.height())); // +2 for borders
+    int height =
+        Math.min(itemCount + 2, screen.height() - (anchor.y() + anchor.height())); // +2 for borders
     if (height < 3) height = Math.min(itemCount + 2, screen.height()); // fall back: clamp to screen
     int x = anchor.x();
     int y = anchor.y() + anchor.height();

--- a/jatatui-components/src/java/jatatui/components/form/FormProvider.java
+++ b/jatatui-components/src/java/jatatui/components/form/FormProvider.java
@@ -30,8 +30,7 @@ public final class FormProvider {
     return component(
         ctx -> {
           State<Map<String, Object>> valuesState = ctx.useState(() -> initial);
-          State<Map<String, String>> errorsState =
-              ctx.useState(() -> validate.apply(initial));
+          State<Map<String, String>> errorsState = ctx.useState(() -> validate.apply(initial));
           State<Boolean> submitting = ctx.useState(() -> false);
           Ref<Function<Map<String, Object>, Map<String, String>>> validateRef =
               ctx.useRef(() -> validate);

--- a/jatatui-components/src/java/jatatui/components/link/Link.java
+++ b/jatatui-components/src/java/jatatui/components/link/Link.java
@@ -34,10 +34,7 @@ public final class Link {
   /// Tab-focusable link with an explicit focus id (for imperative `ctx.focus(id)` / Tab order
   /// stability across reorders).
   public static Element focusable(
-      String focusId,
-      boolean autoFocus,
-      Runnable onActivate,
-      Function<Boolean, Element> content) {
+      String focusId, boolean autoFocus, Runnable onActivate, Function<Boolean, Element> content) {
     return component(
         ctx -> {
           boolean focused = ctx.useFocus(Optional.of(focusId), autoFocus);

--- a/jatatui-components/src/java/jatatui/components/modal/ConfirmDialog.java
+++ b/jatatui-components/src/java/jatatui/components/modal/ConfirmDialog.java
@@ -49,17 +49,13 @@ public final class ConfirmDialog {
             fill(1, empty()),
             length(
                 1,
-                text(
-                    "  enter confirm · esc cancel",
-                    Style.empty().withFg(new Color.DarkGray()))));
+                text("  enter confirm · esc cancel", Style.empty().withFg(new Color.DarkGray()))));
 
     Style boxStyle =
         Style.empty()
             .withFg(danger ? new Color.Red() : new Color.Cyan())
             .withAddModifier(Modifier.BOLD);
     return Modal.of(
-        ModalProps.of(open, title, body, onCancel)
-            .withSize(DEFAULT_SIZE)
-            .withBoxStyle(boxStyle));
+        ModalProps.of(open, title, body, onCancel).withSize(DEFAULT_SIZE).withBoxStyle(boxStyle));
   }
 }

--- a/jatatui-components/src/java/jatatui/components/modal/ModalProps.java
+++ b/jatatui-components/src/java/jatatui/components/modal/ModalProps.java
@@ -34,8 +34,7 @@ public record ModalProps(
   }
 
   public ModalProps withBackdropStyle(Style backdropStyle) {
-    return new ModalProps(
-        open, title, body, onDismiss, size, Optional.of(backdropStyle), boxStyle);
+    return new ModalProps(open, title, body, onDismiss, size, Optional.of(backdropStyle), boxStyle);
   }
 
   public ModalProps withBoxStyle(Style boxStyle) {

--- a/jatatui-components/src/java/jatatui/components/picker/Picker.java
+++ b/jatatui-components/src/java/jatatui/components/picker/Picker.java
@@ -41,7 +41,7 @@ public final class Picker {
   public static <T> Element of(PickerProps<T> props) {
     return component(
         ctx -> {
-          State<String> query       = ctx.useState(() -> "");
+          State<String> query = ctx.useState(() -> "");
           State<Integer> selectedIdx = ctx.useState(() -> 0);
 
           // Forcibly claim focus for the query field on mount. The text input registers with
@@ -53,10 +53,11 @@ public final class Picker {
           ctx.useEffect(() -> ctx.focus(QUERY_FOCUS_ID));
 
           List<T> results = props.filter().apply(query.get());
-          int cap         = Math.min(props.maxVisible(), results.size());
-          List<T> capped  = results.subList(0, cap);
+          int cap = Math.min(props.maxVisible(), results.size());
+          List<T> capped = results.subList(0, cap);
 
-          int sel = capped.isEmpty() ? 0 : Math.max(0, Math.min(selectedIdx.get(), capped.size() - 1));
+          int sel =
+              capped.isEmpty() ? 0 : Math.max(0, Math.min(selectedIdx.get(), capped.size() - 1));
 
           ctx.onKey(
               new KeyCode.Esc(),
@@ -97,9 +98,14 @@ public final class Picker {
                           .withFocusId(QUERY_FOCUS_ID)
                           .withAutoFocus(true)));
 
-          Element resultsPane = capped.isEmpty()
-              ? fill(1, text("  no matches", Style.empty().withFg(new jatatui.core.style.Color.DarkGray())))
-              : fill(1, resultRows(props, capped, sel));
+          Element resultsPane =
+              capped.isEmpty()
+                  ? fill(
+                      1,
+                      text(
+                          "  no matches",
+                          Style.empty().withFg(new jatatui.core.style.Color.DarkGray())))
+                  : fill(1, resultRows(props, capped, sel));
 
           Element modalBody;
           if (props.hint().isPresent()) {
@@ -157,7 +163,7 @@ public final class Picker {
     Element[] rows = new Element[items.size()];
     for (int i = 0; i < items.size(); i++) {
       final int idx = i;
-      final T item  = items.get(i);
+      final T item = items.get(i);
       final boolean selected = idx == selectedIdx;
       rows[i] =
           length(

--- a/jatatui-components/src/java/jatatui/components/picker/PickerProps.java
+++ b/jatatui-components/src/java/jatatui/components/picker/PickerProps.java
@@ -60,18 +60,21 @@ public record PickerProps<T>(
   }
 
   public PickerProps<T> withSize(Size size) {
-    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+    return new PickerProps<>(
+        title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
   }
 
   /// Cap on the number of rows rendered. Beyond ~100 the user re-types instead of scrolling;
   /// rendering more just costs frames.
   public PickerProps<T> withMaxVisible(int maxVisible) {
-    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+    return new PickerProps<>(
+        title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
   }
 
   /// Replace the bottom hint line. Pass [Optional#empty] to drop it entirely.
   public PickerProps<T> withHint(Optional<String> hint) {
-    return new PickerProps<>(title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
+    return new PickerProps<>(
+        title, filter, rowRenderer, onSelect, onCancel, size, maxVisible, hint);
   }
 
   public PickerProps<T> withHint(String hint) {

--- a/jatatui-components/src/java/jatatui/components/textinput/TextInputProps.java
+++ b/jatatui-components/src/java/jatatui/components/textinput/TextInputProps.java
@@ -54,23 +54,322 @@ public record TextInputProps(
         Style.empty().withFg(new jatatui.core.style.Color.Yellow()));
   }
 
-  public TextInputProps withValue(String value) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnChange(Consumer<String> onChange) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withPlaceholder(String placeholder) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withTitle(String title) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusId(String focusId) { return copy(value, onChange, placeholder, title, Optional.of(focusId), autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withAutoFocus(boolean autoFocus) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusOnClick(boolean focusOnClick) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnSubmit(Runnable onSubmit) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, Optional.of(onSubmit), onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withOnCancel(Runnable onCancel) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, Optional.of(onCancel), style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withStyle(Style style) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusedStyle(Style focusedStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withPlaceholderStyle(Style placeholderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withCursorStyle(Style cursorStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withBorderStyle(Style borderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
-  public TextInputProps withFocusedBorderStyle(Style focusedBorderStyle) { return copy(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle); }
+  public TextInputProps withValue(String value) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
 
-  private static TextInputProps copy(String value, Consumer<String> onChange, String placeholder, String title, Optional<String> focusId, boolean autoFocus, boolean focusOnClick, Optional<Runnable> onSubmit, Optional<Runnable> onCancel, Style style, Style focusedStyle, Style placeholderStyle, Style cursorStyle, Style borderStyle, Style focusedBorderStyle) {
-    return new TextInputProps(value, onChange, placeholder, title, focusId, autoFocus, focusOnClick, onSubmit, onCancel, style, focusedStyle, placeholderStyle, cursorStyle, borderStyle, focusedBorderStyle);
+  public TextInputProps withOnChange(Consumer<String> onChange) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withPlaceholder(String placeholder) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withTitle(String title) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withFocusId(String focusId) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        Optional.of(focusId),
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withAutoFocus(boolean autoFocus) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withFocusOnClick(boolean focusOnClick) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withOnSubmit(Runnable onSubmit) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        Optional.of(onSubmit),
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withOnCancel(Runnable onCancel) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        Optional.of(onCancel),
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withStyle(Style style) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withFocusedStyle(Style focusedStyle) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withPlaceholderStyle(Style placeholderStyle) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withCursorStyle(Style cursorStyle) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withBorderStyle(Style borderStyle) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  public TextInputProps withFocusedBorderStyle(Style focusedBorderStyle) {
+    return copy(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
+  }
+
+  private static TextInputProps copy(
+      String value,
+      Consumer<String> onChange,
+      String placeholder,
+      String title,
+      Optional<String> focusId,
+      boolean autoFocus,
+      boolean focusOnClick,
+      Optional<Runnable> onSubmit,
+      Optional<Runnable> onCancel,
+      Style style,
+      Style focusedStyle,
+      Style placeholderStyle,
+      Style cursorStyle,
+      Style borderStyle,
+      Style focusedBorderStyle) {
+    return new TextInputProps(
+        value,
+        onChange,
+        placeholder,
+        title,
+        focusId,
+        autoFocus,
+        focusOnClick,
+        onSubmit,
+        onCancel,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle,
+        borderStyle,
+        focusedBorderStyle);
   }
 }

--- a/jatatui-demo-react/src/java/jatatui/react/examples/bubble/BubbleExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/bubble/BubbleExample.java
@@ -77,11 +77,7 @@ public final class BubbleExample {
   // ---- Nested boxes ----
 
   static Element nestedBoxes(State<List<String>> log) {
-    return outerBox(
-        log,
-        middleBox(
-            log,
-            innerBox(log)));
+    return outerBox(log, middleBox(log, innerBox(log)));
   }
 
   static Element outerBox(State<List<String>> log, Element child) {

--- a/jatatui-demo-react/src/java/jatatui/react/examples/dropdown/DropdownExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/dropdown/DropdownExample.java
@@ -33,16 +33,24 @@ public final class DropdownExample {
           List<String> langs = List.of("Java", "Scala", "Kotlin", "Rust", "Go");
 
           return column(
-                  length(1, text(" dropdown demo  —  Tab to cycle, Enter to open, Esc to quit ",
-                      Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+                  length(
+                      1,
+                      text(
+                          " dropdown demo  —  Tab to cycle, Enter to open, Esc to quit ",
+                          Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
                   length(3, dropdown("Color", colors, color.get(), color::set, "color")),
-                  length(3, dropdown("Size",  sizes,  size.get(),  size::set,  "size")),
-                  length(3, dropdown("Lang",  langs,  lang.get(),  lang::set,  "lang")),
-                  length(2, text(
-                      "Selected: " + colors.get(color.get())
-                          + ", " + sizes.get(size.get())
-                          + ", " + langs.get(lang.get()),
-                      Style.empty().withFg(Color.GRAY))),
+                  length(3, dropdown("Size", sizes, size.get(), size::set, "size")),
+                  length(3, dropdown("Lang", langs, lang.get(), lang::set, "lang")),
+                  length(
+                      2,
+                      text(
+                          "Selected: "
+                              + colors.get(color.get())
+                              + ", "
+                              + sizes.get(size.get())
+                              + ", "
+                              + langs.get(lang.get()),
+                          Style.empty().withFg(Color.GRAY))),
                   fill(1, text("")))
               .with(p -> p.withSpacing(1).withMargin(new Margin(2, 1)));
         });

--- a/jatatui-demo-react/src/java/jatatui/react/examples/form/FormExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/form/FormExample.java
@@ -11,7 +11,6 @@ import jatatui.core.style.Color;
 import jatatui.core.style.Style;
 import jatatui.react.Element;
 import jatatui.react.ReactApp;
-import jatatui.widgets.Borders;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,25 +73,36 @@ public final class FormExample {
               });
 
           return column(
-                  length(1, text(" form demo  —  Tab to cycle, Ctrl-S submit, Ctrl-R reset, Esc to quit ",
-                      Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
-                  length(3,
+                  length(
+                      1,
+                      text(
+                          " form demo  —  Tab to cycle, Ctrl-S submit, Ctrl-R reset, Esc to quit ",
+                          Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+                  length(
+                      3,
                       titledTextInput(
                           "Name" + (name.hasError() ? " (!)" : ""),
-                          name.value(), name.setValue(),
-                          "your name", "name")),
-                  length(1, text(name.error().orElse(""),
-                      Style.empty().withFg(Color.RED))),
-                  length(3,
+                          name.value(),
+                          name.setValue(),
+                          "your name",
+                          "name")),
+                  length(1, text(name.error().orElse(""), Style.empty().withFg(Color.RED))),
+                  length(
+                      3,
                       titledTextInput(
                           "Email" + (email.hasError() ? " (!)" : ""),
-                          email.value(), email.setValue(),
-                          "you@example.com", "email")),
-                  length(1, text(email.error().orElse(""),
-                      Style.empty().withFg(Color.RED))),
-                  length(2, text(
-                      form.hasErrors() ? "Form has errors — fix before submitting." : "Form OK — Ctrl-S to submit.",
-                      Style.empty().withFg(form.hasErrors() ? Color.RED : Color.GREEN))),
+                          email.value(),
+                          email.setValue(),
+                          "you@example.com",
+                          "email")),
+                  length(1, text(email.error().orElse(""), Style.empty().withFg(Color.RED))),
+                  length(
+                      2,
+                      text(
+                          form.hasErrors()
+                              ? "Form has errors — fix before submitting."
+                              : "Form OK — Ctrl-S to submit.",
+                          Style.empty().withFg(form.hasErrors() ? Color.RED : Color.GREEN))),
                   fill(1, text("")))
               .with(p -> p.withSpacing(1).withMargin(new Margin(2, 1)));
         });

--- a/jatatui-demo-react/src/java/jatatui/react/examples/modal/ModalExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/modal/ModalExample.java
@@ -29,28 +29,41 @@ public final class ModalExample {
           ctx.onGlobalKey(new KeyCode.Char('o'), () -> open.set(true));
 
           return column(
-                  length(1, text(" modal demo  —  press 'o' to open, Esc/click outside to close, q to quit ",
-                      Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
-                  length(3,
-                      button("  [ Open Modal ]  ",
+                  length(
+                      1,
+                      text(
+                          " modal demo  —  press 'o' to open, Esc/click outside to close, q to quit"
+                              + " ",
+                          Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+                  length(
+                      3,
+                      button(
+                          "  [ Open Modal ]  ",
                           Style.empty().withFg(Color.YELLOW),
                           () -> open.set(true))),
-                  fill(1,
-                      box(" Background content ",
+                  fill(
+                      1,
+                      box(
+                          " Background content ",
                           Borders.ALL,
                           text("This is the underlying UI. The modal will paint over it."),
                           text(""),
                           text("Try clicking through the backdrop — the click is intercepted."),
                           text("Try clicking inside the modal box — the click stays local."))),
-                  modal(open.get(), " Modal Title ",
+                  modal(
+                      open.get(),
+                      " Modal Title ",
                       column(
                           text("This is the modal body."),
                           text(""),
                           text("Esc dismisses, click outside dismisses,"),
                           text("clicks inside stay local."),
                           text(""),
-                          length(1, text("  [Press Esc or click outside]",
-                              Style.empty().withFg(Color.GRAY)))),
+                          length(
+                              1,
+                              text(
+                                  "  [Press Esc or click outside]",
+                                  Style.empty().withFg(Color.GRAY)))),
                       () -> open.set(false)))
               .with(p -> p.withSpacing(1).withMargin(new Margin(2, 1)));
         });

--- a/jatatui-demo-react/src/java/jatatui/react/examples/router/RouterExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/router/RouterExample.java
@@ -30,11 +30,15 @@ public final class RouterExample {
           RouterApi r = RouterApi.useRouter(ctx);
           ctx.onGlobalKey(new KeyCode.Char('s'), () -> r.push("settings", settings()));
           ctx.onGlobalKey(new KeyCode.Char('a'), () -> r.push("about", about()));
-          return chrome(r,
+          return chrome(
+              r,
               column(
                   length(1, text("Welcome to Home.", Style.empty().withFg(Color.WHITE))),
-                  length(2, text("Press 's' for Settings, 'a' for About.",
-                      Style.empty().withFg(Color.GRAY))),
+                  length(
+                      2,
+                      text(
+                          "Press 's' for Settings, 'a' for About.",
+                          Style.empty().withFg(Color.GRAY))),
                   fill(1, text(""))));
         });
   }
@@ -44,11 +48,15 @@ public final class RouterExample {
         ctx -> {
           RouterApi r = RouterApi.useRouter(ctx);
           ctx.onGlobalKey(new KeyCode.Backspace(), r::pop);
-          return chrome(r,
+          return chrome(
+              r,
               column(
                   length(1, text("Settings page.", Style.empty().withFg(Color.WHITE))),
-                  length(2, text("Press 'Backspace' to go back, 'a' to push About on top.",
-                      Style.empty().withFg(Color.GRAY))),
+                  length(
+                      2,
+                      text(
+                          "Press 'Backspace' to go back, 'a' to push About on top.",
+                          Style.empty().withFg(Color.GRAY))),
                   whenInline(ctx, r),
                   fill(1, text(""))));
         });
@@ -59,11 +67,11 @@ public final class RouterExample {
         ctx -> {
           RouterApi r = RouterApi.useRouter(ctx);
           ctx.onGlobalKey(new KeyCode.Backspace(), r::pop);
-          return chrome(r,
+          return chrome(
+              r,
               column(
                   length(1, text("About this app.", Style.empty().withFg(Color.WHITE))),
-                  length(2, text("Built with jatatui-react.",
-                      Style.empty().withFg(Color.GRAY))),
+                  length(2, text("Built with jatatui-react.", Style.empty().withFg(Color.GRAY))),
                   fill(1, text(""))));
         });
   }
@@ -71,8 +79,11 @@ public final class RouterExample {
   /// Push About onto a settings screen — small "open about from settings" affordance.
   static Element whenInline(jatatui.react.RenderContext ctx, RouterApi r) {
     ctx.onGlobalKey(new KeyCode.Char('a'), () -> r.push("about", about()));
-    return length(1, text("(or press 'a' to push About on top of Settings)",
-        Style.empty().withFg(Color.DARK_GRAY)));
+    return length(
+        1,
+        text(
+            "(or press 'a' to push About on top of Settings)",
+            Style.empty().withFg(Color.DARK_GRAY)));
   }
 
   /// Common chrome: breadcrumb on top + the screen body.
@@ -83,10 +94,8 @@ public final class RouterExample {
       bc.append(r.stack().get(i).label());
     }
     return column(
-            length(1, text(bc.toString(),
-                Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
-            length(1, text(" Backspace=pop  Esc=quit  ",
-                Style.empty().withFg(Color.GRAY))),
+            length(1, text(bc.toString(), Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+            length(1, text(" Backspace=pop  Esc=quit  ", Style.empty().withFg(Color.GRAY))),
             fill(1, box(" Screen ", Borders.ALL, body)))
         .with(p -> p.withSpacing(0).withMargin(new Margin(1, 1)));
   }

--- a/jatatui-demo-react/src/java/jatatui/react/examples/showcase/ShowcaseExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/showcase/ShowcaseExample.java
@@ -110,8 +110,7 @@ public final class ShowcaseExample {
 
   // ---- Body ----
 
-  static Element body(
-      int selected, int count, jatatui.react.State<List<String>> messages) {
+  static Element body(int selected, int count, jatatui.react.State<List<String>> messages) {
     return switch (selected) {
       case 0 -> homeTab(count, messages);
       case 1 -> statsTab(count, messages.get().size());

--- a/jatatui-demo-react/src/java/jatatui/react/examples/textinput/TextInputExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/textinput/TextInputExample.java
@@ -27,11 +27,18 @@ public final class TextInputExample {
           var email = ctx.useState(() -> "");
 
           return column(
-                  length(1, text(" textInput demo  —  Tab to cycle, Esc to quit ",
-                      Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
-                  length(3, titledTextInput("Name",  name.get(),  name::set,  "first name",      "name")),
-                  length(3, titledTextInput("Email", email.get(), email::set, "you@example.com", "email")),
-                  length(2,
+                  length(
+                      1,
+                      text(
+                          " textInput demo  —  Tab to cycle, Esc to quit ",
+                          Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+                  length(3, titledTextInput("Name", name.get(), name::set, "first name", "name")),
+                  length(
+                      3,
+                      titledTextInput(
+                          "Email", email.get(), email::set, "you@example.com", "email")),
+                  length(
+                      2,
                       text(
                           "Echo: name=\"" + name.get() + "\"  email=\"" + email.get() + "\"",
                           Style.empty().withFg(Color.GRAY))),

--- a/jatatui-demo-react/src/java/jatatui/react/examples/theme/ThemeExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/theme/ThemeExample.java
@@ -36,9 +36,9 @@ public final class ThemeExample {
         ctx -> {
           Theme theme = Theme.useTheme(ctx);
           return column(
-                  length(1, text(" theme demo  —  press 't' to toggle, Esc to quit ", theme.title())),
-                  length(3,
-                      box(" Title ", Borders.ALL, text("Themed body text", theme.page()))),
+                  length(
+                      1, text(" theme demo  —  press 't' to toggle, Esc to quit ", theme.title())),
+                  length(3, box(" Title ", Borders.ALL, text("Themed body text", theme.page()))),
                   length(2, text("Accent text", theme.accent())),
                   length(1, text("Success — operation completed", theme.success())),
                   length(1, text("Warning — heads up", theme.warning())),

--- a/jatatui-demo-react/src/java/jatatui/react/examples/toast/ToastExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/toast/ToastExample.java
@@ -34,12 +34,21 @@ public final class ToastExample {
           ctx.onGlobalKey(new KeyCode.Char('c'), toasts::dismissAll);
 
           return column(
-                  length(1, text(" toast demo  —  i / s / w / e to add a toast, c to clear, Esc to quit ",
-                      Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
-                  length(2, text("Toasts auto-dismiss after 3 seconds.",
-                      Style.empty().withFg(Color.GRAY))),
-                  fill(1, text("Press i, s, w, e to add. Press c to clear all.",
-                      Style.empty().withFg(Color.WHITE))))
+                  length(
+                      1,
+                      text(
+                          " toast demo  —  i / s / w / e to add a toast, c to clear, Esc to quit ",
+                          Style.empty().withFg(Color.WHITE).withBg(Color.BLUE))),
+                  length(
+                      2,
+                      text(
+                          "Toasts auto-dismiss after 3 seconds.",
+                          Style.empty().withFg(Color.GRAY))),
+                  fill(
+                      1,
+                      text(
+                          "Press i, s, w, e to add. Press c to clear all.",
+                          Style.empty().withFg(Color.WHITE))))
               .with(p -> p.withSpacing(1).withMargin(new Margin(2, 1)));
         });
   }

--- a/jatatui-react/src/java/jatatui/react/Components.java
+++ b/jatatui-react/src/java/jatatui/react/Components.java
@@ -121,8 +121,7 @@ public final class Components {
   public static Element.Of<Intrinsics.RowProps> row(Element... children) {
     return new Element.Of<>(
         Intrinsics.ROW,
-        new Intrinsics.RowProps(
-            List.of(children), Flex.Legacy, Spacing.DEFAULT, new Margin(0, 0)),
+        new Intrinsics.RowProps(List.of(children), Flex.Legacy, Spacing.DEFAULT, new Margin(0, 0)),
         Optional.empty());
   }
 
@@ -182,16 +181,16 @@ public final class Components {
 
   public static Element ifElse(boolean condition, Element then_, Element else_) {
     return new Element.Of<>(
-        Intrinsics.IF_ELSE,
-        new Intrinsics.IfElseProps(condition, then_, else_),
-        Optional.empty());
+        Intrinsics.IF_ELSE, new Intrinsics.IfElseProps(condition, then_, else_), Optional.empty());
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static <T> Element forEach(
       List<T> items, Function<T, String> keyFn, Function<T, Element> render) {
     return new Element.Of<>(
-        Intrinsics.FOR_EACH, new Intrinsics.ForEachProps(items, keyFn, render, 1), Optional.empty());
+        Intrinsics.FOR_EACH,
+        new Intrinsics.ForEachProps(items, keyFn, render, 1),
+        Optional.empty());
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/jatatui-react/src/java/jatatui/react/Element.java
+++ b/jatatui-react/src/java/jatatui/react/Element.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 ///
 /// Three permits, deliberately minimal:
 ///   - [Of] — application of a [Component] to its props (the universal "user component" form)
-///   - [Host] — a leaf that paints directly via an [Intrinsic] (escape hatch; rarely authored by users)
+///   - [Host] — a leaf that paints directly via an [Intrinsic] (escape hatch; rarely authored by
+// users)
 ///   - [Sized] — pure layout metadata: a [Constraint] attached to a child, read by parent layouts
 ///
 /// All built-in factories (`text`, `box`, `column`, `row`, `tabs`, `forEach`, `button`, etc.)

--- a/jatatui-react/src/java/jatatui/react/Element.java
+++ b/jatatui-react/src/java/jatatui/react/Element.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 ///
 /// Three permits, deliberately minimal:
 ///   - [Of] — application of a [Component] to its props (the universal "user component" form)
-///   - [Host] — a leaf that paints directly via an [Intrinsic] (escape hatch; rarely authored by
-// users)
+///   - [Host] — a leaf that paints directly via an [Intrinsic] (escape hatch; rarely
+///     authored by users)
 ///   - [Sized] — pure layout metadata: a [Constraint] attached to a child, read by parent layouts
 ///
 /// All built-in factories (`text`, `box`, `column`, `row`, `tabs`, `forEach`, `button`, etc.)

--- a/jatatui-react/src/java/jatatui/react/EventRegistry.java
+++ b/jatatui-react/src/java/jatatui/react/EventRegistry.java
@@ -13,9 +13,10 @@ import java.util.function.Consumer;
 ///
 /// Storage is bucketed by [Fiber] (not flat) so dispatch can walk the parent chain of a focused or
 /// hit-tested target. This is the React-DOM bubbling model:
-///   - **Mouse**: hit-test finds the deepest Fiber whose recorded bounds contain (x,y); we then walk
-///     from that Fiber up to root, firing matching click/scroll handlers along the way. Handlers
-///     can call [MouseEvent#stopPropagation] to prevent further ancestors from being notified.
+///   - **Mouse**: hit-test finds the deepest Fiber whose recorded bounds contain (x,y); we then
+///     walk from that Fiber up to root, firing matching click/scroll handlers along the way.
+///     Handlers can call [MouseEvent#stopPropagation] to prevent further ancestors from being
+///     notified.
 ///   - **Key**: walk from the focused Fiber up to root, firing matching key handlers. Then global
 ///     key handlers fire (lowest priority — last-resort shortcuts). [KeyEvent#stopPropagation]
 ///     stops the chain anywhere along it.

--- a/jatatui-react/src/java/jatatui/react/Intrinsics.java
+++ b/jatatui-react/src/java/jatatui/react/Intrinsics.java
@@ -64,7 +64,8 @@ public final class Intrinsics {
   /// Holds a `Consumer<MouseEvent>` so handlers that care can `stopPropagation` or read modifiers.
   /// The `Runnable`-flavored `Components.button(...)` factory wraps a Runnable into a Consumer
   /// that ignores the event.
-  public record ButtonProps(String label, Style style, java.util.function.Consumer<MouseEvent> onClick) {}
+  public record ButtonProps(
+      String label, Style style, java.util.function.Consumer<MouseEvent> onClick) {}
 
   public static final Component<ButtonProps> BUTTON =
       (props, ctx) ->
@@ -100,8 +101,7 @@ public final class Intrinsics {
 
   // -------------------- Column / Row (vertical / horizontal layout) --------------------
 
-  public record ColumnProps(
-      List<Element> children, Flex flex, Spacing spacing, Margin margin) {
+  public record ColumnProps(List<Element> children, Flex flex, Spacing spacing, Margin margin) {
     public ColumnProps withFlex(Flex f) {
       return new ColumnProps(children, f, spacing, margin);
     }
@@ -177,7 +177,8 @@ public final class Intrinsics {
                     .withStyle(Style.empty().withFg(Color.GRAY))
                     .render(split[0], c.buffer());
                 if (props.selected() >= 0 && props.selected() < props.tabs().size()) {
-                  c.renderChild(props.selected(), props.tabs().get(props.selected()).body(), split[1]);
+                  c.renderChild(
+                      props.selected(), props.tabs().get(props.selected()).body(), split[1]);
                 }
               });
 
@@ -211,7 +212,9 @@ public final class Intrinsics {
 
   public static final Component<WhenProps> WHEN =
       (props, ctx) ->
-          props.condition() ? props.child() : new Element.Of<>(EMPTY, new EmptyProps(), Optional.empty());
+          props.condition()
+              ? props.child()
+              : new Element.Of<>(EMPTY, new EmptyProps(), Optional.empty());
 
   public record IfElseProps(boolean condition, Element thenChild, Element elseChild) {}
 
@@ -256,9 +259,7 @@ public final class Intrinsics {
   public record PortalProps(Element child, Rect area) {}
 
   public static final Component<PortalProps> PORTAL =
-      (props, ctx) ->
-          new Element.Host(
-              (c, area) -> c.queuePortal(props.child(), props.area()));
+      (props, ctx) -> new Element.Host((c, area) -> c.queuePortal(props.child(), props.area()));
 
   // -------------------- Widget wrap --------------------
 
@@ -299,8 +300,7 @@ public final class Intrinsics {
   /// memoized user components.
   public record FunctionProps(Function<RenderContext, Element> body) {}
 
-  public static final Component<FunctionProps> FUNCTION =
-      (props, ctx) -> props.body().apply(ctx);
+  public static final Component<FunctionProps> FUNCTION = (props, ctx) -> props.body().apply(ctx);
 
   // -------------------- Shared helpers --------------------
 

--- a/jatatui-react/src/java/jatatui/react/Renderer.java
+++ b/jatatui-react/src/java/jatatui/react/Renderer.java
@@ -11,8 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /// screens — see [#resetState]). Per frame:
 ///
 /// 1. From inside `terminal.draw(frame -> { ... })`: call [#render]
-/// 2. After `terminal.draw` returns: dispatch any input events via [#dispatchKey] / [#dispatchMouse],
-///    cycle focus via [#tab] / [#shiftTab], check [#takeDirty] for the next iteration.
+/// 2. After `terminal.draw` returns: dispatch any input events via [#dispatchKey] /
+///    [#dispatchMouse], cycle focus via [#tab] / [#shiftTab], check [#takeDirty] for the next
+///    iteration.
 ///
 /// Example loop skeleton:
 /// ```

--- a/jatatui-tests/src/java/jatatui/components/button/ButtonTest.java
+++ b/jatatui-tests/src/java/jatatui/components/button/ButtonTest.java
@@ -20,9 +20,7 @@ class ButtonTest {
   void click_activates() throws IOException {
     AtomicInteger n = new AtomicInteger();
     Element app =
-        column(
-                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
-                fill(1, text("")))
+        column(length(3, Button.of("Save", "save", true, n::incrementAndGet)), fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
     TestHarness h = new TestHarness(40, 10);
@@ -35,9 +33,7 @@ class ButtonTest {
   void enter_activates_when_focused() throws IOException {
     AtomicInteger n = new AtomicInteger();
     Element app =
-        column(
-                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
-                fill(1, text("")))
+        column(length(3, Button.of("Save", "save", true, n::incrementAndGet)), fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
     TestHarness h = new TestHarness(40, 10);
@@ -52,9 +48,7 @@ class ButtonTest {
   void enter_does_nothing_when_not_focused() throws IOException {
     AtomicInteger n = new AtomicInteger();
     Element app =
-        column(
-                length(3, Button.of("Save", "save", true, n::incrementAndGet)),
-                fill(1, text("")))
+        column(length(3, Button.of("Save", "save", true, n::incrementAndGet)), fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
     TestHarness h = new TestHarness(40, 10);

--- a/jatatui-tests/src/java/jatatui/components/chrome/BackButtonTest.java
+++ b/jatatui-tests/src/java/jatatui/components/chrome/BackButtonTest.java
@@ -18,7 +18,8 @@ class BackButtonTest {
   void click_inside_chip_invokes_back() throws IOException {
     AtomicInteger backCount = new AtomicInteger();
     Element app =
-        column(length(BackButton.HEIGHT, BackButton.of("sources", backCount::incrementAndGet)),
+        column(
+                length(BackButton.HEIGHT, BackButton.of("sources", backCount::incrementAndGet)),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
@@ -34,7 +35,8 @@ class BackButtonTest {
   void click_past_chip_edge_does_not_invoke_back() throws IOException {
     AtomicInteger backCount = new AtomicInteger();
     Element app =
-        column(length(BackButton.HEIGHT, BackButton.of("x", backCount::incrementAndGet)),
+        column(
+                length(BackButton.HEIGHT, BackButton.of("x", backCount::incrementAndGet)),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 

--- a/jatatui-tests/src/java/jatatui/components/chrome/ScreenFrameTest.java
+++ b/jatatui-tests/src/java/jatatui/components/chrome/ScreenFrameTest.java
@@ -38,8 +38,7 @@ class ScreenFrameTest {
   @Test
   void clicking_back_chip_invokes_back() throws IOException {
     AtomicInteger backCount = new AtomicInteger();
-    Element app =
-        ScreenFrame.of("home", backCount::incrementAndGet, text("body"));
+    Element app = ScreenFrame.of("home", backCount::incrementAndGet, text("body"));
 
     TestHarness h = new TestHarness(40, 12);
     h.render(app);

--- a/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
+++ b/jatatui-tests/src/java/jatatui/components/dropdown/DropdownTest.java
@@ -26,13 +26,17 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3, dropdown("Color", List.of("red", "green", "blue", "yellow"),
-                    selected.get(),
-                    i -> {
-                      selected.set(i);
-                      changeCount.incrementAndGet();
-                    },
-                    "color")),
+                length(
+                    3,
+                    dropdown(
+                        "Color",
+                        List.of("red", "green", "blue", "yellow"),
+                        selected.get(),
+                        i -> {
+                          selected.set(i);
+                          changeCount.incrementAndGet();
+                        },
+                        "color")),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
@@ -40,15 +44,13 @@ class DropdownTest {
     h.render(app);
 
     // Click the trigger (top of the column, rows 0..2). Anywhere in row 1 lands inside the box.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
     // Now the option list is open just below the trigger. Default size: 4 items + 2 borders =
     // 6 rows starting at y=3. Row content (after the top border at y=3) starts at y=4.
     // Click on the third item ("blue") which sits at y=6.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
     assertEquals(1, changeCount.get(), "click on option row should fire onChange exactly once");
@@ -57,8 +59,7 @@ class DropdownTest {
     // After committing, dropdown should be closed — re-render shouldn't paint the option list,
     // and clicking where the option list was should NOT re-commit.
     int countBefore = changeCount.get();
-    h.events.dispatchMouse(
-        new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 6, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
     assertEquals(countBefore, changeCount.get(), "dropdown is closed; click does not commit");
   }
@@ -73,13 +74,17 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3, dropdown("Color", List.of("red", "green", "blue"),
-                    selected.get(),
-                    i -> {
-                      selected.set(i);
-                      changeCount.incrementAndGet();
-                    },
-                    "color")),
+                length(
+                    3,
+                    dropdown(
+                        "Color",
+                        List.of("red", "green", "blue"),
+                        selected.get(),
+                        i -> {
+                          selected.set(i);
+                          changeCount.incrementAndGet();
+                        },
+                        "color")),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 
@@ -87,8 +92,7 @@ class DropdownTest {
     h.render(app);
 
     // Open with click — also focuses the dropdown.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
     // Press Down twice: highlight 0 → 1 → 2 (blue).
@@ -109,7 +113,11 @@ class DropdownTest {
   }
 
   /// Dropdown is generic over `T` — typed options (here an enum) work with a labelFn.
-  enum Color { RED, GREEN, BLUE }
+  enum Color {
+    RED,
+    GREEN,
+    BLUE
+  }
 
   @Test
   void typed_options_via_labelfn() throws IOException {
@@ -118,7 +126,8 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3,
+                length(
+                    3,
                     jatatui.components.Components.dropdown(
                         DropdownProps.of(
                                 "Color",
@@ -157,13 +166,17 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3, dropdown("A", List.of("red", "green", "blue"),
-                    selected.get(),
-                    i -> {
-                      selected.set(i);
-                      changeCount.incrementAndGet();
-                    },
-                    "a")),
+                length(
+                    3,
+                    dropdown(
+                        "A",
+                        List.of("red", "green", "blue"),
+                        selected.get(),
+                        i -> {
+                          selected.set(i);
+                          changeCount.incrementAndGet();
+                        },
+                        "a")),
                 length(3, dropdown("B", List.of("p", "q"), 0, i -> {}, "b")),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
@@ -172,8 +185,7 @@ class DropdownTest {
     h.render(app);
 
     // Open A.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
     // Move highlight 0 → 1 → 2 (blue).
@@ -201,10 +213,14 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3, dropdown("A", List.of("red", "green", "blue"),
-                    1, // start with green selected
-                    i -> changeCount.incrementAndGet(),
-                    "a")),
+                length(
+                    3,
+                    dropdown(
+                        "A",
+                        List.of("red", "green", "blue"),
+                        1, // start with green selected
+                        i -> changeCount.incrementAndGet(),
+                        "a")),
                 length(3, dropdown("B", List.of("p", "q"), 0, i -> {}, "b")),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
@@ -213,8 +229,7 @@ class DropdownTest {
     h.render(app);
 
     // Open A (highlight initialized to selectedIndex = 1).
-    h.events.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
     // Tab away — same highlight as selection, no onChange.
@@ -240,23 +255,20 @@ class DropdownTest {
     h.render(app);
 
     // Open the first dropdown.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
-    assertEquals(java.util.Optional.of("a"), h.focus.currentlyFocused(),
-        "click on A's trigger focused A");
+    assertEquals(
+        java.util.Optional.of("a"), h.focus.currentlyFocused(), "click on A's trigger focused A");
 
     // Move focus to B (Tab in ReactApp would do focus.tab(); we call it directly for the test).
     h.renderer.tab();
     h.render(app);
-    assertEquals(java.util.Optional.of("b"), h.focus.currentlyFocused(),
-        "focus moved to B");
+    assertEquals(java.util.Optional.of("b"), h.focus.currentlyFocused(), "focus moved to B");
 
     // The first dropdown's open list should no longer respond — Down on B doesn't change A.
     // We can't easily inspect openState directly, but the symptom would be: clicking where A's
     // open-list used to be re-fires onChange. After auto-close, that click does nothing.
-    h.events.dispatchMouse(
-        new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
     // No commit happened on either dropdown — implicit assertion (no exception, focus still B).
     assertEquals(java.util.Optional.of("b"), h.focus.currentlyFocused());
@@ -269,10 +281,14 @@ class DropdownTest {
 
     Element app =
         column(
-                length(3, dropdown("Color", List.of("red", "green", "blue"),
-                    0,
-                    i -> changeCount.incrementAndGet(),
-                    "color")),
+                length(
+                    3,
+                    dropdown(
+                        "Color",
+                        List.of("red", "green", "blue"),
+                        0,
+                        i -> changeCount.incrementAndGet(),
+                        "color")),
                 fill(1, text("")))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
 

--- a/jatatui-tests/src/java/jatatui/components/form/FormTest.java
+++ b/jatatui-tests/src/java/jatatui/components/form/FormTest.java
@@ -25,8 +25,7 @@ class FormTest {
               apiRef.set(FormApi.useForm(ctx));
               return text("ok");
             });
-    Element app =
-        formProvider(Map.of("name", "Alice", "age", 30), values -> {}, child);
+    Element app = formProvider(Map.of("name", "Alice", "age", 30), values -> {}, child);
     new TestHarness(40, 12).render(app);
     assertEquals("Alice", apiRef.get().getValue("name").orElse(null));
     assertEquals(30, apiRef.get().getValue("age").orElse(null));
@@ -117,8 +116,7 @@ class FormTest {
               apiRef.set(FormApi.useForm(ctx));
               return text("ok");
             });
-    Element app =
-        formProvider(Map.of("name", "Alice"), values -> submitted.set(true), child);
+    Element app = formProvider(Map.of("name", "Alice"), values -> submitted.set(true), child);
     new TestHarness(40, 12).render(app);
     apiRef.get().submit();
     assertTrue(submitted.get());
@@ -142,5 +140,4 @@ class FormTest {
     h.render(app);
     assertEquals("Alice", apiRef.get().getValue("name").orElse(null));
   }
-
 }

--- a/jatatui-tests/src/java/jatatui/components/modal/ConfirmDialogTest.java
+++ b/jatatui-tests/src/java/jatatui/components/modal/ConfirmDialogTest.java
@@ -42,14 +42,7 @@ class ConfirmDialogTest {
     AtomicInteger cancelCount = new AtomicInteger();
     Element app =
         ConfirmDialog.of(
-            true,
-            " Delete ",
-            "?",
-            "Yes",
-            "No",
-            false,
-            () -> {},
-            cancelCount::incrementAndGet);
+            true, " Delete ", "?", "Yes", "No", false, () -> {}, cancelCount::incrementAndGet);
 
     TestHarness h = new TestHarness(100, 30);
     h.render(app);
@@ -63,14 +56,7 @@ class ConfirmDialogTest {
     AtomicInteger cancelCount = new AtomicInteger();
     Element app =
         ConfirmDialog.of(
-            false,
-            " Delete ",
-            "?",
-            "Yes",
-            "No",
-            false,
-            () -> {},
-            cancelCount::incrementAndGet);
+            false, " Delete ", "?", "Yes", "No", false, () -> {}, cancelCount::incrementAndGet);
 
     TestHarness h = new TestHarness(100, 30);
     h.render(app);

--- a/jatatui-tests/src/java/jatatui/components/modal/ModalTest.java
+++ b/jatatui-tests/src/java/jatatui/components/modal/ModalTest.java
@@ -24,8 +24,7 @@ class ModalTest {
 
     Element app =
         column(
-                length(3,
-                    button("  [ Open Modal ]  ", Style.empty(), () -> buttonFired.set(true))),
+                length(3, button("  [ Open Modal ]  ", Style.empty(), () -> buttonFired.set(true))),
                 fill(1, text("background")),
                 modal(true, " Modal ", text("body"), () -> dismissed.set(true)))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));
@@ -72,8 +71,7 @@ class ModalTest {
 
     Element app =
         column(
-                length(3,
-                    button("  [ Open Modal ]  ", Style.empty(), () -> buttonFired.set(true))),
+                length(3, button("  [ Open Modal ]  ", Style.empty(), () -> buttonFired.set(true))),
                 fill(1, text("bg")),
                 modal(false, " Modal ", text("body"), () -> {}))
             .with(p -> p.withSpacing(0).withMargin(new Margin(0, 0)));

--- a/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
+++ b/jatatui-tests/src/java/jatatui/components/picker/PickerTest.java
@@ -84,11 +84,7 @@ class PickerTest {
     AtomicReference<String> selected = new AtomicReference<>();
     PickerProps<String> props =
         PickerProps.of(
-            " Pick ",
-            substring(List.of("a", "b", "c")),
-            textRow(),
-            selected::set,
-            () -> {});
+            " Pick ", substring(List.of("a", "b", "c")), textRow(), selected::set, () -> {});
 
     TestHarness h = new TestHarness(120, 30);
     h.render(pickerApp(props));
@@ -107,11 +103,7 @@ class PickerTest {
     AtomicReference<String> selected = new AtomicReference<>();
     PickerProps<String> props =
         PickerProps.of(
-            " Pick ",
-            substring(List.of("a", "b", "c")),
-            textRow(),
-            selected::set,
-            () -> {});
+            " Pick ", substring(List.of("a", "b", "c")), textRow(), selected::set, () -> {});
 
     TestHarness h = new TestHarness(120, 30);
     h.render(pickerApp(props));
@@ -158,8 +150,7 @@ class PickerTest {
 
     // Picker is 80x20 centered in 120x30 → modal covers (20..99, 5..24). Click at (5, 1) is
     // outside.
-    h.renderer.dispatchMouse(
-        new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.renderer.dispatchMouse(new MouseEvent(5, 1, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     assertEquals(1, cancelCount.get());
   }
 
@@ -180,8 +171,7 @@ class PickerTest {
     // Modal centered in 120x30 with size 80x20 → top-left at (20, 5). Inside the box border
     // the textinput takes 3 rows, then results start at y = 5 + 1 (top border) + 3 (input).
     // First result row is at y = 9. Click on it.
-    h.renderer.dispatchMouse(
-        new MouseEvent(30, 9, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.renderer.dispatchMouse(new MouseEvent(30, 9, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     assertEquals("apple", selected.get());
   }
 
@@ -221,12 +211,7 @@ class PickerTest {
         new java.util.concurrent.atomic.AtomicBoolean(false);
 
     PickerProps<String> props =
-        PickerProps.of(
-            " Pick ",
-            substring(List.of("a", "b", "c")),
-            textRow(),
-            s -> {},
-            () -> {});
+        PickerProps.of(" Pick ", substring(List.of("a", "b", "c")), textRow(), s -> {}, () -> {});
 
     Element app =
         component(

--- a/jatatui-tests/src/java/jatatui/components/router/RouterTest.java
+++ b/jatatui-tests/src/java/jatatui/components/router/RouterTest.java
@@ -171,5 +171,4 @@ class RouterTest {
     assertEquals(1, apiRef.get().depth());
     assertEquals("home", apiRef.get().current().label());
   }
-
 }

--- a/jatatui-tests/src/java/jatatui/components/search/FuzzyMatchTest.java
+++ b/jatatui-tests/src/java/jatatui/components/search/FuzzyMatchTest.java
@@ -67,9 +67,7 @@ class FuzzyMatchTest {
     List<String> ranked = FuzzyMatch.rank("cn", indexed);
     assertTrue(ranked.contains("customer_name"));
     assertEquals(
-        "customer_name",
-        ranked.get(0),
-        "highest-scoring (word-start on both chars) ranks first");
+        "customer_name", ranked.get(0), "highest-scoring (word-start on both chars) ranks first");
     assertFalse(ranked.contains("order_total"), "non-matching items dropped");
   }
 

--- a/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
+++ b/jatatui-tests/src/java/jatatui/components/selectablelist/SelectableListTest.java
@@ -258,7 +258,8 @@ class SelectableListTest {
     h.renderer.dispatchMouse(new MouseEvent(2, 2, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     h.render(app);
 
-    assertEquals(0, activations.get(), "second click outside double-click window does not activate");
+    assertEquals(
+        0, activations.get(), "second click outside double-click window does not activate");
   }
 
   @Test
@@ -502,11 +503,7 @@ class SelectableListTest {
             ctx ->
                 jatatui.components.Components.selectableList(
                     SelectableListProps.of(
-                            rows,
-                            r -> true,
-                            magentaRenderer,
-                            selectedIdx.get(),
-                            selectedIdx::set)
+                            rows, r -> true, magentaRenderer, selectedIdx.get(), selectedIdx::set)
                         .withFocusId("list")
                         .withAutoFocus(true)));
 

--- a/jatatui-tests/src/java/jatatui/components/textinput/TextInputClickToFocusTest.java
+++ b/jatatui-tests/src/java/jatatui/components/textinput/TextInputClickToFocusTest.java
@@ -42,8 +42,7 @@ class TextInputClickToFocusTest {
     assertEquals(List.of(true, false), focusFlags, "first input is auto-focused");
 
     // Click in the second input's area (rows 3..5 of the column).
-    h.events.dispatchMouse(
-        new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     focusFlags.clear();
     h.render(app);
     assertEquals(List.of(false, true), focusFlags, "click on input b transfers focus");
@@ -72,15 +71,19 @@ class TextInputClickToFocusTest {
     h.render(app);
     assertEquals(List.of(true, false), focusFlags);
 
-    h.events.dispatchMouse(
-        new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
+    h.events.dispatchMouse(new MouseEvent(5, 4, new KeyModifiers(0), MouseEvent.Kind.DOWN));
     focusFlags.clear();
     h.render(app);
-    assertEquals(List.of(true, false), focusFlags, "focus stays on first when click-to-focus is disabled");
+    assertEquals(
+        List.of(true, false), focusFlags, "focus stays on first when click-to-focus is disabled");
   }
 
   static Element namedField(
-      jatatui.react.RenderContext outerCtx, List<Boolean> flags, List<String> values, int idx, String id) {
+      jatatui.react.RenderContext outerCtx,
+      List<Boolean> flags,
+      List<String> values,
+      int idx,
+      String id) {
     return component(
         ctx -> {
           flags.add(ctx.useFocus(java.util.Optional.of(id), idx == 0));
@@ -90,7 +93,11 @@ class TextInputClickToFocusTest {
   }
 
   static Element namedFieldNoClick(
-      jatatui.react.RenderContext outerCtx, List<Boolean> flags, List<String> values, int idx, String id) {
+      jatatui.react.RenderContext outerCtx,
+      List<Boolean> flags,
+      List<String> values,
+      int idx,
+      String id) {
     return component(
         ctx -> {
           flags.add(ctx.useFocus(java.util.Optional.of(id), idx == 0));

--- a/jatatui-tests/src/java/jatatui/react/EventBubblingIntegrationTest.java
+++ b/jatatui-tests/src/java/jatatui/react/EventBubblingIntegrationTest.java
@@ -151,7 +151,9 @@ class EventBubblingIntegrationTest {
     h.focus().tab();
     log.clear();
 
-    assertEquals(Optional.of("inner"), h.focus().currentlyFocused(),
+    assertEquals(
+        Optional.of("inner"),
+        h.focus().currentlyFocused(),
         "tab cycle should reach inner after two presses");
 
     KeyEvent ev = new KeyEvent(new KeyCode.Char('a'), new KeyModifiers(0));

--- a/jatatui-tests/src/java/jatatui/react/EventRegistryDispatchTest.java
+++ b/jatatui-tests/src/java/jatatui/react/EventRegistryDispatchTest.java
@@ -58,7 +58,7 @@ class EventRegistryDispatchTest {
 
     List<String> log = new ArrayList<>();
     r.addKey(inner, new KeyCode.Char('a'), e -> log.add("inner-a"));
-    r.addKey(middle, new KeyCode.Char('b'), e -> log.add("middle-b"));    // wrong key
+    r.addKey(middle, new KeyCode.Char('b'), e -> log.add("middle-b")); // wrong key
     r.addKey(outer, new KeyCode.Char('a'), e -> log.add("outer-a"));
 
     KeyEvent ev = new KeyEvent(new KeyCode.Char('a'), new KeyModifiers(0));
@@ -75,10 +75,13 @@ class EventRegistryDispatchTest {
     Fiber inner = middle.child(0);
 
     List<String> log = new ArrayList<>();
-    r.addKey(inner, new KeyCode.Char('a'), e -> {
-      log.add("inner");
-      e.stopPropagation();
-    });
+    r.addKey(
+        inner,
+        new KeyCode.Char('a'),
+        e -> {
+          log.add("inner");
+          e.stopPropagation();
+        });
     r.addKey(middle, new KeyCode.Char('a'), e -> log.add("middle"));
     r.addKey(outer, new KeyCode.Char('a'), e -> log.add("outer"));
 
@@ -111,10 +114,13 @@ class EventRegistryDispatchTest {
     Fiber outer = Fiber.root().child(0);
 
     List<String> log = new ArrayList<>();
-    r.addKey(outer, new KeyCode.Char('q'), e -> {
-      log.add("outer");
-      e.stopPropagation();
-    });
+    r.addKey(
+        outer,
+        new KeyCode.Char('q'),
+        e -> {
+          log.add("outer");
+          e.stopPropagation();
+        });
     r.addGlobalKey(new KeyCode.Char('q'), e -> log.add("global"));
 
     KeyEvent ev = new KeyEvent(new KeyCode.Char('q'), new KeyModifiers(0));
@@ -195,10 +201,13 @@ class EventRegistryDispatchTest {
     r.recordBounds(inner, a);
 
     List<String> log = new ArrayList<>();
-    r.addClick(inner, a, e -> {
-      log.add("inner");
-      e.stopPropagation();
-    });
+    r.addClick(
+        inner,
+        a,
+        e -> {
+          log.add("inner");
+          e.stopPropagation();
+        });
     r.addClick(outer, a, e -> log.add("outer"));
 
     MouseEvent ev = new MouseEvent(5, 5, new KeyModifiers(0), MouseEvent.Kind.DOWN);

--- a/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ImperativeFocusTest.java
@@ -112,14 +112,18 @@ class ImperativeFocusTest {
   void screen_change_requests_rerender_so_new_focus_paints_next_tick() throws IOException {
     TestHarness h = new TestHarness(40, 12);
 
-    Element screenA = component(ctx -> {
-      ctx.useFocus(Optional.of("A"), true);
-      return text("A");
-    });
-    Element screenB = component(ctx -> {
-      ctx.useFocus(Optional.of("B"), true);
-      return text("B");
-    });
+    Element screenA =
+        component(
+            ctx -> {
+              ctx.useFocus(Optional.of("A"), true);
+              return text("A");
+            });
+    Element screenB =
+        component(
+            ctx -> {
+              ctx.useFocus(Optional.of("B"), true);
+              return text("B");
+            });
 
     java.util.concurrent.atomic.AtomicBoolean showA =
         new java.util.concurrent.atomic.AtomicBoolean(true);

--- a/jatatui-tests/src/java/jatatui/react/PortalTest.java
+++ b/jatatui-tests/src/java/jatatui/react/PortalTest.java
@@ -19,15 +19,12 @@ class PortalTest {
   @Test
   void portal_renders_after_main_pass() throws IOException {
     // Main pass writes "BG" to the buffer; portal writes "FG" at same area. Portal must win.
-    Element child =
-        text("FG", Style.empty().withFg(Color.WHITE).withBg(Color.BLUE));
-    Element app =
-        column(
-            text("BG"),
-            portal(child, new Rect(0, 0, 5, 1)));
+    Element child = text("FG", Style.empty().withFg(Color.WHITE).withBg(Color.BLUE));
+    Element app = column(text("BG"), portal(child, new Rect(0, 0, 5, 1)));
     String[] rows = renderToText(app, 10, 3);
     // The first row should now be "FG" (portal overpainted), not "BG".
-    assertTrue(rows[0].startsWith("FG"), "portal must paint over main pass; got: '" + rows[0] + "'");
+    assertTrue(
+        rows[0].startsWith("FG"), "portal must paint over main pass; got: '" + rows[0] + "'");
   }
 
   @Test
@@ -64,7 +61,8 @@ class PortalTest {
         });
 
     // Click inside the portal area
-    MouseEvent click = new MouseEvent(2, 5, new tui.crossterm.KeyModifiers(0), MouseEvent.Kind.DOWN);
+    MouseEvent click =
+        new MouseEvent(2, 5, new tui.crossterm.KeyModifiers(0), MouseEvent.Kind.DOWN);
     events.dispatchMouse(click);
     assertTrue(parentSawClick.get(), "click on portal must bubble to declaring parent");
   }
@@ -73,9 +71,7 @@ class PortalTest {
   void multiple_portals_render_in_declaration_order() throws IOException {
     // Two portals at the same area; second overwrites first.
     Element app =
-        column(
-            portal(text("AA"), new Rect(0, 0, 5, 1)),
-            portal(text("BB"), new Rect(0, 0, 5, 1)));
+        column(portal(text("AA"), new Rect(0, 0, 5, 1)), portal(text("BB"), new Rect(0, 0, 5, 1)));
     String[] rows = renderToText(app, 10, 3);
     assertTrue(rows[0].startsWith("BB"), "second portal wins; got: '" + rows[0] + "'");
   }

--- a/jatatui-tests/src/java/jatatui/react/ReactAppFocusKeyTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ReactAppFocusKeyTest.java
@@ -64,8 +64,7 @@ class ReactAppFocusKeyTest {
         frame -> {
           app.events.clear();
           app.focus.clearFrame();
-          RenderContext ctx =
-              new RenderContext(frame, app.events, app.hooks, app.focus, () -> {});
+          RenderContext ctx = new RenderContext(frame, app.events, app.hooks, app.focus, () -> {});
           app.events.recordBounds(Fiber.root(), frame.area());
           root.render(ctx, frame.area());
         });

--- a/jatatui-tests/src/java/jatatui/react/ReconciliationTest.java
+++ b/jatatui-tests/src/java/jatatui/react/ReconciliationTest.java
@@ -50,8 +50,7 @@ class ReconciliationTest {
 
     showA.set(false);
     h.render(wrapper);
-    assertEquals(
-        "hello", seen.get(), "different component at same fiber → fresh useState initial");
+    assertEquals("hello", seen.get(), "different component at same fiber → fresh useState initial");
 
     showA.set(true);
     h.render(wrapper);
@@ -123,18 +122,24 @@ class ReconciliationTest {
         (props, ctx) ->
             text(
                 "A:"
-                    + (Integer) ctx.useState(() -> {
-                      seen.set("A-init");
-                      return props * 10;
-                    }).get());
+                    + (Integer)
+                        ctx.useState(
+                                () -> {
+                                  seen.set("A-init");
+                                  return props * 10;
+                                })
+                            .get());
     Component<Integer> compB =
         (props, ctx) ->
             text(
                 "B:"
-                    + (Integer) ctx.useState(() -> {
-                      seen.set("B-init");
-                      return props + 100;
-                    }).get());
+                    + (Integer)
+                        ctx.useState(
+                                () -> {
+                                  seen.set("B-init");
+                                  return props + 100;
+                                })
+                            .get());
 
     AtomicBoolean useA = new AtomicBoolean(true);
     Element wrapper = component(ctx -> useA.get() ? apply(compA, 5) : apply(compB, 7));

--- a/jatatui-tests/src/java/jatatui/react/RendererTest.java
+++ b/jatatui-tests/src/java/jatatui/react/RendererTest.java
@@ -89,8 +89,7 @@ class RendererTest {
     drawOnce(r, app);
     r.clearDirty();
 
-    boolean fired =
-        r.dispatchKey(new KeyEvent(new KeyCode.Char('a'), new KeyModifiers(0)));
+    boolean fired = r.dispatchKey(new KeyEvent(new KeyCode.Char('a'), new KeyModifiers(0)));
     assertTrue(fired);
     assertEquals(1, pressed.get());
   }
@@ -145,10 +144,11 @@ class RendererTest {
                     initialCount.incrementAndGet();
                     return 0;
                   });
-              ctx.useEffect(() -> {
-                // Effect registers a cleanup, but our useEffect API runs `effect` and the
-                // cleanup must be registered by the effect's body. Here we just simulate.
-              });
+              ctx.useEffect(
+                  () -> {
+                    // Effect registers a cleanup, but our useEffect API runs `effect` and the
+                    // cleanup must be registered by the effect's body. Here we just simulate.
+                  });
               return text("with-state");
             });
 

--- a/jatatui-tests/src/java/jatatui/react/StateUpdateTest.java
+++ b/jatatui-tests/src/java/jatatui/react/StateUpdateTest.java
@@ -41,8 +41,7 @@ class StateUpdateTest {
                   innerCtx -> {
                     innerCtx.useFocus(Optional.of("outer"), true);
                     innerCtx.onKey(
-                        new KeyCode.Char('a'),
-                        () -> log.update(prev -> append(prev, "outer")));
+                        new KeyCode.Char('a'), () -> log.update(prev -> append(prev, "outer")));
                     return box(
                         " Outer ",
                         Borders.ALL,
@@ -80,10 +79,8 @@ class StateUpdateTest {
     // The State stored in HookStore should contain all three messages.
     @SuppressWarnings("unchecked")
     List<String> finalLog =
-        (List<String>) hooks.values.values().stream()
-            .filter(v -> v instanceof List)
-            .findFirst()
-            .orElseThrow();
+        (List<String>)
+            hooks.values.values().stream().filter(v -> v instanceof List).findFirst().orElseThrow();
 
     assertEquals(List.of("inner", "middle", "outer"), finalLog);
   }
@@ -129,10 +126,8 @@ class StateUpdateTest {
 
     @SuppressWarnings("unchecked")
     List<String> finalLog =
-        (List<String>) hooks.values.values().stream()
-            .filter(v -> v instanceof List)
-            .findFirst()
-            .orElseThrow();
+        (List<String>)
+            hooks.values.values().stream().filter(v -> v instanceof List).findFirst().orElseThrow();
 
     assertEquals(List.of("inner", "middle", "outer"), finalLog);
   }
@@ -156,9 +151,7 @@ class StateUpdateTest {
                       length(1, text(" header ")),
                       fill(
                           1,
-                          row(
-                                  fill(2, nestedClickBoxes(log)),
-                                  fill(1, text(" log panel ")))
+                          row(fill(2, nestedClickBoxes(log)), fill(1, text(" log panel ")))
                               .with(p -> p.withSpacing(1))),
                       length(1, text(" hint ")))
                   .with(p -> p.withMargin(new jatatui.core.layout.Margin(1, 0)));
@@ -173,10 +166,8 @@ class StateUpdateTest {
 
     @SuppressWarnings("unchecked")
     List<String> finalLog =
-        (List<String>) hooks.values.values().stream()
-            .filter(v -> v instanceof List)
-            .findFirst()
-            .orElseThrow();
+        (List<String>)
+            hooks.values.values().stream().filter(v -> v instanceof List).findFirst().orElseThrow();
 
     assertEquals(List.of("inner", "middle", "outer"), finalLog);
   }

--- a/jatatui-tests/src/java/jatatui/react/UseTimeoutTest.java
+++ b/jatatui-tests/src/java/jatatui/react/UseTimeoutTest.java
@@ -3,7 +3,6 @@ package jatatui.react;
 import static jatatui.react.Components.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;

--- a/jatatui-widgets/src/java/jatatui/widgets/input/TextInput.java
+++ b/jatatui-widgets/src/java/jatatui/widgets/input/TextInput.java
@@ -66,39 +66,120 @@ public final class TextInput implements Widget {
   }
 
   public TextInput withValue(String value) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withCursorPos(int cursorPos) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withScrollOffset(int scrollOffset) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withFocused(boolean focused) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withPlaceholder(String placeholder) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withStyle(Style style) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withFocusedStyle(Style focusedStyle) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withPlaceholderStyle(Style placeholderStyle) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   public TextInput withCursorStyle(Style cursorStyle) {
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
+        scrollOffset,
+        focused,
+        placeholder,
+        style,
+        focusedStyle,
+        placeholderStyle,
+        cursorStyle);
   }
 
   // ---- Render ----


### PR DESCRIPTION
Three commits: a whole-repo reformat, a CI gate so it cannot happen again, and a small doc-comment
fix the gate turned up. Kept out of #81 so that PR stays about the JNI config.

## 1. 45 files were committed unformatted

`bleep fmt` rewrites 45 tracked files. This is not taste-level rewrapping — it is 140-column lines
that google-java-format splits into its 100-column style:

```java
-    return new TextInput(value, cursorPos, scrollOffset, focused, placeholder, style, focusedStyle, placeholderStyle, cursorStyle);
+    return new TextInput(
+        value,
+        cursorPos,
...
```

Spread across `jatatui-components` (11), `jatatui-tests` (21), `jatatui-demo-react` (9),
`jatatui-react` (3) and `jatatui-widgets` (1) — the shape of it points at the lift-from-typr import
landing without a `bleep fmt`. Pure formatting, no behavioural content.

**This is not a formatter-version artefact.** It is the obvious suspicion, so I checked it: gjf
**1.33.0** (what the pinned bleep `1.0.0-M9` resolves) and gjf **1.35.0** (what a bleep snapshot
build uses) produce **byte-identical** output over these files. I diffed the two results against
each other — they agree line for line. The files really were unformatted, under either version.

The reformat was produced by the released bleep launcher, so the version pinned in `bleep.yaml`
chose the formatter.

## 2. A gate so it stays clean

`bleep fmt --check` already exists and exits non-zero naming the offending files, so no
`git diff --exit-code` scaffolding is needed. It goes in as a step in the existing `build` job,
which is renamed `Format + compile + test`:

```yaml
      - name: Check formatting
        run: bleep fmt --check

      - name: Show formatting diff
        if: failure()
        run: |
          bleep fmt
          git --no-pager diff
```

It runs through the plain `bleep` launcher like every other step in the workflow, so it reads
`$version` from `bleep.yaml` and checks with the same scalafmt and google-java-format versions a
contributor gets from `bleep fmt`. A gate that formats with a different version than contributors do
would be worse than no gate at all.

`--check` says *which* files are wrong but not *what* is wrong with them, which makes for a red
build with nothing to act on. The second step runs only on failure, reformats, and prints the diff,
so the log shows the exact lines to change.

### Verified in both directions, for real, on this PR

- **Green**: an earlier push of this branch — identical except for the two files discussed below —
  passed `Format + compile + test` in CI, compile and full test suite included.
- **Red when it should be**: padding a line in `TextInput.java` past 100 columns locally makes
  `bleep fmt --check` exit 1 and name the file. Reverted, not committed.
- **Red for real, unplanned**, which is the best evidence of all: the gate's *first* CI run failed
  on two genuinely unformatted files, and the `Show formatting diff` step printed exactly the lines
  at fault. Both the check and its diagnostic have now run in anger.

## 3. `///` doc comments, and why one of them is hand-wrapped

Turning the gate on immediately caught something worth knowing about. google-java-format 1.33.0
predates Java's `///` markdown doc comments and treats them as ordinary line comments, so when one
runs past 100 columns it wraps the overflow onto a plain `//` line:

```java
///   - **Mouse**: hit-test finds the deepest Fiber ...; we then
// walk
```

That is not a formatting difference — the continuation stops being part of the doc comment. The
reformat introduced exactly one of these, in `Element.java`, so the last commit hand-wraps that line
under 100 columns instead: the prose stays intact and the formatter has nothing left to do.

**`main` already carries 51 doc comments mangled this exact way** by earlier formatter runs, across
`jatatui-core`, `jatatui-widgets`, `crossterm` and others — `Strength.java` alone has 9. This PR
does not touch them and the gate does not object to them, because once mangled the result is stable.
But they are broken docs, and the count grows every time someone writes a `///` line past 100
columns. Worth deciding separately whether to hand-wrap them or teach the formatter to leave `///`
alone.

## Known: the gate is red on two files, and that is the correct answer

`bleep fmt --check` fails on `jatatui-react/src/java/jatatui/react/EventRegistry.java` and
`.../Renderer.java`. Each has exactly one `///` line over 100 columns (101 and 102), which the
formatter wants to break into a `//` continuation.

I have deliberately **not** touched those two files here. Both have in-flight uncommitted work in
them, and committing to them would mean a contributor cannot switch branches without stashing
mid-edit. The working copies already satisfy the gate — so landing that work, on this branch or
before it, turns the check green with no further action. Merging this PR before that work lands
would put a red gate on `main`; merging after is clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
