### PR TITLE
react: useFrame, and full mouse (hover, drag, drag-end)

### DIFF
--- a/jatatui-demo-react/src/java/jatatui/react/examples/Launcher.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/Launcher.java
@@ -18,6 +18,7 @@ public final class Launcher {
 
   static {
     EXAMPLES.put("bubble", "jatatui.react.examples.bubble.BubbleExample");
+    EXAMPLES.put("frame", "jatatui.react.examples.frame.FrameExample");
     EXAMPLES.put("counter", "jatatui.react.examples.counter.CounterExample");
     EXAMPLES.put("list", "jatatui.react.examples.list.ListExample");
     EXAMPLES.put("table", "jatatui.react.examples.table.TableExample");

--- a/jatatui-demo-react/src/java/jatatui/react/examples/frame/FrameExample.java
+++ b/jatatui-demo-react/src/java/jatatui/react/examples/frame/FrameExample.java
@@ -1,0 +1,184 @@
+package jatatui.react.examples.frame;
+
+import static jatatui.react.Components.*;
+
+import jatatui.core.layout.Rect;
+import jatatui.core.style.Color;
+import jatatui.core.style.Style;
+import jatatui.react.Element;
+import jatatui.react.ReactApp;
+import jatatui.widgets.Borders;
+import java.io.IOException;
+import java.util.Optional;
+
+/// End-to-end demo of the animation + full-mouse additions to jatatui-react:
+///
+///   - **`useFrame(60, dt)`** drives a flowing gradient bar with NO hand-rolled render loop — the
+///     declarative layer schedules the ticks and shortens the poll while mounted.
+///   - **`onHover`** highlights the file row under the pointer (move the mouse over the list).
+///   - **`onDrag` / `onDragEnd`** scrub the timeline at the bottom: press and drag to move the
+///     caret; release to stop. Reads the live pointer x each drag.
+///
+/// Run: `jatatui-demo-react` launcher → `frame`. Quit with `q` / `Esc` / Ctrl-C.
+public final class FrameExample {
+
+  // "Unicorn" palette (matches the dfmt design brief).
+  private static final int[] IRIS = {0xa7, 0x8b, 0xfa};
+  private static final int[] ROSE = {0xfb, 0x71, 0x85};
+  private static final Color MINT = new Color.Rgb(0x34, 0xd3, 0x99);
+  private static final Color LILAC = new Color.Rgb(0x6d, 0x5c, 0x9e);
+  private static final Color ASH = new Color.Rgb(0x3b, 0x35, 0x50);
+
+  private static final String[] FILES = {
+    "models/staging/stg_orders.sql",
+    "models/staging/stg_customers.sql",
+    "models/marts/fct_orders.sql",
+    "models/marts/dim_customers.sql",
+    "models/metrics/revenue.sql",
+  };
+
+  public static void main(String[] args) throws IOException {
+    ReactApp.run(app());
+  }
+
+  static Element app() {
+    return component(
+        ctx -> {
+          // Animation clock, advanced by real elapsed ms each frame → frame-rate independent.
+          var phaseMs = ctx.useState(() -> 0.0);
+          var hoveredRow = ctx.useState(() -> -1);
+          var scrub = ctx.useState(() -> 0.35); // 0..1
+          var dragging = ctx.useState(() -> false);
+
+          ctx.useFrame(60, elapsed -> phaseMs.update(p -> p + elapsed));
+
+          return box(
+              " useFrame + mouse demo ",
+              Borders.ALL,
+              length(1, text("")),
+              length(
+                  1,
+                  text(
+                      "  flowing gradient — animated at 60fps via useFrame (no manual loop)",
+                      Style.empty().withFg(LILAC))),
+              length(1, flowBar(phaseMs.get())),
+              length(1, text("")),
+              length(
+                  1,
+                  text(
+                      "  hover a file row (move the mouse over it):", Style.empty().withFg(LILAC))),
+              fill(1, fileList(hoveredRow.get(), i -> hoveredRow.set(i))),
+              length(1, text("")),
+              length(
+                  1,
+                  text(
+                      "  drag to scrub the timeline (press + drag, release to stop):",
+                      Style.empty().withFg(LILAC))),
+              length(1, scrubBar(scrub, dragging)),
+              length(1, footer(scrub.get(), dragging.get())));
+        });
+  }
+
+  // ---- Animated flow bar (useFrame) ----
+
+  static Element flowBar(double phaseMs) {
+    return widget(
+        (Rect area, jatatui.core.buffer.Buffer buf) -> {
+          int w = area.width();
+          for (int i = 0; i < w; i++) {
+            double t = w <= 1 ? 0.0 : (double) i / (w - 1);
+            // A travelling wave: position drives hue phase, the frame clock streams it L→R.
+            double wave = 0.5 + 0.5 * Math.sin(t * Math.PI * 3.0 - phaseMs * 0.006);
+            double brightness = 0.35 + 0.65 * wave;
+            Color c = lerp(IRIS, ROSE, t, brightness);
+            buf.setString(area.x() + i, area.y(), "█", Style.empty().withFg(c));
+          }
+        });
+  }
+
+  // ---- Hover-highlighted file list ----
+
+  static Element fileList(int hovered, java.util.function.IntConsumer onHover) {
+    Element[] rows = new Element[FILES.length];
+    for (int i = 0; i < FILES.length; i++) {
+      rows[i] = length(1, fileRow(i, FILES[i], hovered == i, onHover));
+    }
+    return column(rows);
+  }
+
+  static Element fileRow(
+      int index, String name, boolean hovered, java.util.function.IntConsumer onHover) {
+    return component(
+        ctx -> {
+          ctx.onHover(() -> onHover.accept(index));
+          Style style =
+              hovered ? Style.empty().withFg(Color.WHITE).withBg(ASH) : Style.empty().withFg(MINT);
+          String marker = hovered ? "  ▸ " : "    ";
+          return text(marker + name + "   +3 -1", style);
+        });
+  }
+
+  // ---- Drag-scrubbable timeline ----
+
+  static Element scrubBar(
+      jatatui.react.State<Double> scrub, jatatui.react.State<Boolean> dragging) {
+    return component(
+        ctx -> {
+          Optional<Rect> areaOpt = ctx.area();
+          ctx.onDrag(
+              e ->
+                  areaOpt.ifPresent(
+                      r -> {
+                        int span = Math.max(1, r.width() - 1);
+                        double frac = (double) (e.x() - r.x()) / span;
+                        scrub.set(clamp01(frac));
+                        dragging.set(true);
+                      }));
+          ctx.onDragEnd(() -> dragging.set(false));
+
+          double pos = scrub.get();
+          boolean isDragging = dragging.get();
+          return widget(
+              (Rect area, jatatui.core.buffer.Buffer buf) -> {
+                int w = area.width();
+                for (int i = 0; i < w; i++) {
+                  buf.setString(area.x() + i, area.y(), "─", Style.empty().withFg(ASH));
+                }
+                int caret = (int) Math.round(pos * Math.max(0, w - 1));
+                Color caretColor =
+                    isDragging
+                        ? new Color.Rgb(ROSE[0], ROSE[1], ROSE[2])
+                        : new Color.Rgb(IRIS[0], IRIS[1], IRIS[2]);
+                buf.setString(area.x() + caret, area.y(), "◆", Style.empty().withFg(caretColor));
+              });
+        });
+  }
+
+  static Element footer(double scrub, boolean dragging) {
+    String pct = String.format("%3d%%", (int) Math.round(scrub * 100));
+    String state = dragging ? "dragging" : "idle";
+    return text(
+        "  scrub " + pct + "  (" + state + ")     Esc / Ctrl-C to quit",
+        Style.empty().withFg(dragging ? new Color.Rgb(ROSE[0], ROSE[1], ROSE[2]) : LILAC));
+  }
+
+  // ---- Color helpers ----
+
+  /// Interpolate between two RGB triples at `t` (0..1), then scale toward black by `brightness`.
+  private static Color lerp(int[] a, int[] b, double t, double brightness) {
+    int r = (int) ((a[0] + (b[0] - a[0]) * t) * brightness);
+    int g = (int) ((a[1] + (b[1] - a[1]) * t) * brightness);
+    int bb = (int) ((a[2] + (b[2] - a[2]) * t) * brightness);
+    return new Color.Rgb(clamp8(r), clamp8(g), clamp8(bb));
+  }
+
+  private static int clamp8(int v) {
+    return Math.max(0, Math.min(255, v));
+  }
+
+  private static double clamp01(double v) {
+    return Math.max(0.0, Math.min(1.0, v));
+  }
+
+  private FrameExample() {}
+}

--- a/jatatui-react/src/java/jatatui/react/EventRegistry.java
+++ b/jatatui-react/src/java/jatatui/react/EventRegistry.java
@@ -13,44 +13,82 @@ import java.util.function.Consumer;
 ///
 /// Storage is bucketed by [Fiber] (not flat) so dispatch can walk the parent chain of a focused or
 /// hit-tested target. This is the React-DOM bubbling model:
-///   - **Mouse**: hit-test finds the deepest Fiber whose recorded bounds contain (x,y); we then
-///     walk from that Fiber up to root, firing matching click/scroll handlers along the way.
-///     Handlers can call [MouseEvent#stopPropagation] to prevent further ancestors from being
-///     notified.
+///   - **Mouse**: hit-test finds the topmost Fiber whose recorded bounds contain (x,y) —
+///     "topmost" resolved by paint order (see below), NOT merely fiber depth; we then walk from
+///     that Fiber up to root, firing matching handlers along the way. Handlers can call
+///     [MouseEvent#stopPropagation] to prevent further ancestors from being notified.
 ///   - **Key**: walk from the focused Fiber up to root, firing matching key handlers. Then global
 ///     key handlers fire (lowest priority — last-resort shortcuts). [KeyEvent#stopPropagation]
 ///     stops the chain anywhere along it.
+///
+/// ## Z-order / paint-order hit-testing
+///
+/// The buffer is immediate-mode: a cell's visible content is whatever painted it **last**. So the
+/// widget a user "sees" at a point is the last one to paint there. Hit-testing must agree with
+/// that, otherwise clicking a modal would fall through to the widget behind it.
+///
+/// We capture paint order directly. [#recordBounds] is called in pre-order traversal — a fiber
+/// records its bounds immediately before its subtree paints — so the recording order **is** the
+/// paint order. Each record carries:
+///   - `z`   — a layer index. The main pass is layer 0; each generation of portals drained after
+///             the main pass gets a strictly higher layer (see [RenderContext#drainPortals]). This
+///             makes portals (modals, dropdowns, tooltips) win hit-tests over the main content they
+///             overlap, regardless of how deep in the fiber tree that content sits.
+///   - `seq` — a monotonically increasing paint sequence number within the frame. Uniquely orders
+///             every record, so within a layer "last painted wins" (a later sibling over an earlier
+///             one; a child over its parent) with no ties to break arbitrarily.
+///
+/// Hit resolution picks the containing bound with the greatest `(z, seq)`. This subsumes the old
+/// depth heuristic (a nested child paints after its parent → higher seq → still wins) while also
+/// handling the two cases depth got wrong: equal-depth overlapping siblings (resolved by paint
+/// order, not `HashMap` iteration order) and portals (resolved by layer, not depth).
 public final class EventRegistry {
 
-  // Per-fiber handler buckets
+  // Per-fiber handler buckets, one per routed mouse kind.
   private final Map<Fiber, List<AreaHandler>> clickByFiber = new HashMap<>();
   private final Map<Fiber, List<AreaHandler>> scrollByFiber = new HashMap<>();
+  private final Map<Fiber, List<AreaHandler>> hoverByFiber = new HashMap<>();
+  private final Map<Fiber, List<AreaHandler>> dragByFiber = new HashMap<>();
+  private final Map<Fiber, List<AreaHandler>> dragEndByFiber = new HashMap<>();
   private final Map<Fiber, List<KeyHandler>> keysByFiber = new HashMap<>();
 
   // Global key handlers (no fiber, fire after fiber-bubble)
   private final List<KeyHandler> globalKeys = new ArrayList<>();
 
-  // Per-fiber recorded bounds — used for hit-testing
-  private final Map<Fiber, Rect> bounds = new HashMap<>();
+  // Per-fiber recorded bounds — used for hit-testing. Carries paint order (z, seq).
+  private final Map<Fiber, Bound> bounds = new HashMap<>();
+  private int seqCounter;
 
   void clear() {
     clickByFiber.clear();
     scrollByFiber.clear();
+    hoverByFiber.clear();
+    dragByFiber.clear();
+    dragEndByFiber.clear();
     keysByFiber.clear();
     globalKeys.clear();
     bounds.clear();
+    seqCounter = 0;
   }
 
   // -------------------- Registration --------------------
 
+  /// Record `f`'s bounds for hit-testing at paint layer `z`. Called in pre-order during render, so
+  /// the call order is the paint order; each record gets the next paint sequence number.
+  void recordBounds(Fiber f, Rect r, int z) {
+    bounds.put(f, new Bound(r, z, seqCounter++));
+  }
+
+  /// Record `f`'s bounds on the base paint layer (z = 0). Convenience for callers that don't deal
+  /// in portal layers (e.g. the root bound, direct unit tests).
   void recordBounds(Fiber f, Rect r) {
-    bounds.put(f, r);
+    recordBounds(f, r, 0);
   }
 
   /// The bounds last recorded for `f` this frame, if any. Used by `RenderContext.area()` so
   /// components can register handlers "for my whole area" without re-threading the Rect.
   Optional<Rect> boundsOf(Fiber f) {
-    return Optional.ofNullable(bounds.get(f));
+    return Optional.ofNullable(bounds.get(f)).map(Bound::rect);
   }
 
   void addClick(Fiber f, Rect area, Consumer<MouseEvent> handler) {
@@ -59,6 +97,18 @@ public final class EventRegistry {
 
   void addScroll(Fiber f, Rect area, Consumer<MouseEvent> handler) {
     scrollByFiber.computeIfAbsent(f, k -> new ArrayList<>()).add(new AreaHandler(area, handler));
+  }
+
+  void addHover(Fiber f, Rect area, Consumer<MouseEvent> handler) {
+    hoverByFiber.computeIfAbsent(f, k -> new ArrayList<>()).add(new AreaHandler(area, handler));
+  }
+
+  void addDrag(Fiber f, Rect area, Consumer<MouseEvent> handler) {
+    dragByFiber.computeIfAbsent(f, k -> new ArrayList<>()).add(new AreaHandler(area, handler));
+  }
+
+  void addDragEnd(Fiber f, Rect area, Consumer<MouseEvent> handler) {
+    dragEndByFiber.computeIfAbsent(f, k -> new ArrayList<>()).add(new AreaHandler(area, handler));
   }
 
   void addKey(Fiber f, Object matcher, Consumer<KeyEvent> handler) {
@@ -71,19 +121,20 @@ public final class EventRegistry {
 
   // -------------------- Dispatch --------------------
 
-  /// Dispatch a mouse event to the deepest fiber containing (x,y) and bubble up. Returns true if
-  /// any handler fired.
+  /// Dispatch a mouse event to the topmost fiber containing (x,y) and bubble up. Every mouse kind
+  /// routes to its own handler bucket: `DOWN`→click, `SCROLL_*`→scroll, `MOVE`→hover, `DRAG`→drag,
+  /// `UP`→drag-end. Returns true if any handler fired.
   public boolean dispatchMouse(MouseEvent ev) {
     Map<Fiber, List<AreaHandler>> bucket =
         switch (ev.kind()) {
           case DOWN -> clickByFiber;
           case SCROLL_UP, SCROLL_DOWN -> scrollByFiber;
-          // UP, DRAG, MOVE: not currently delivered (no public API yet)
-          default -> null;
+          case MOVE -> hoverByFiber;
+          case DRAG -> dragByFiber;
+          case UP -> dragEndByFiber;
         };
-    if (bucket == null) return false;
 
-    Fiber target = deepestAt(ev.x(), ev.y());
+    Fiber target = topmostAt(ev.x(), ev.y());
     if (target == null) return false;
 
     boolean fired = false;
@@ -140,18 +191,20 @@ public final class EventRegistry {
 
   // -------------------- Hit testing --------------------
 
-  /// Find the deepest fiber whose recorded bounds contain (x,y). Returns null if none.
-  private Fiber deepestAt(int x, int y) {
+  /// Find the topmost fiber whose recorded bounds contain (x,y): the containing bound with the
+  /// greatest `(z, seq)`. `z` (paint layer) dominates so portals win over the content they cover;
+  /// within a layer `seq` (paint order) breaks ties so the last-painted widget wins. Returns null
+  /// if no recorded bound contains the point.
+  private Fiber topmostAt(int x, int y) {
     Fiber best = null;
-    int bestDepth = -1;
-    for (Map.Entry<Fiber, Rect> e : bounds.entrySet()) {
-      Rect r = e.getValue();
-      if (contains(r, x, y)) {
-        int d = e.getKey().depth();
-        if (d > bestDepth) {
-          best = e.getKey();
-          bestDepth = d;
-        }
+    int bestZ = Integer.MIN_VALUE;
+    int bestSeq = Integer.MIN_VALUE;
+    for (Map.Entry<Fiber, Bound> e : bounds.entrySet()) {
+      Bound b = e.getValue();
+      if (contains(b.rect(), x, y) && (b.z() > bestZ || (b.z() == bestZ && b.seq() > bestSeq))) {
+        best = e.getKey();
+        bestZ = b.z();
+        bestSeq = b.seq();
       }
     }
     return best;
@@ -175,4 +228,8 @@ public final class EventRegistry {
   private record AreaHandler(Rect area, Consumer<MouseEvent> handler) {}
 
   private record KeyHandler(Object matcher, Consumer<KeyEvent> handler) {}
+
+  /// A fiber's recorded bounds plus its paint-order coordinates. `z` is the paint layer (0 = main
+  /// pass, higher = later portal generations); `seq` is the paint sequence within the frame.
+  private record Bound(Rect rect, int z, int seq) {}
 }

--- a/jatatui-react/src/java/jatatui/react/ReactApp.java
+++ b/jatatui-react/src/java/jatatui/react/ReactApp.java
@@ -72,9 +72,12 @@ public final class ReactApp {
       if (renderer.takeDirty()) {
         terminal.draw(frame -> renderer.render(frame, root));
       }
-      // Poll with 100ms timeout so timer-driven re-renders (toasts, animations) wake the loop
-      // promptly. Pure event-driven for app correctness — the loop body just re-checks `dirty`.
-      if (jni.poll(new Duration(0L, 100_000_000))) {
+      // Poll timeout: 100ms normally (timer-driven re-renders like toasts wake the loop promptly),
+      // but ~8ms while a `useFrame` tick source is live so its frame-rate re-renders are picked up
+      // at animation speed (~60fps-capable). Pure event-driven for app correctness — the loop body
+      // just re-checks `dirty`.
+      int pollNanos = renderer.frameActive() ? 8_000_000 : 100_000_000;
+      if (jni.poll(new Duration(0L, pollNanos))) {
         Event ev = jni.read();
         running = handle(ev);
       }

--- a/jatatui-react/src/java/jatatui/react/RenderContext.java
+++ b/jatatui-react/src/java/jatatui/react/RenderContext.java
@@ -33,6 +33,12 @@ public final class RenderContext {
   final java.util.List<PortalEntry> portals = new java.util.ArrayList<>();
   Fiber fiber;
   int hookIndex;
+  /// The paint layer bounds are recorded at. 0 during the main pass; bumped per portal generation
+  /// in [#drainPortals] so portals hit-test above the content they overlap. See [EventRegistry].
+  int currentZ = 0;
+  /// The highest `hz` requested by any [#useFrame] mounted this render, or 0 if none. Read by
+  /// [Renderer] after render to drive (or stop) the frame tick source at the right rate.
+  int frameMaxHz = 0;
 
   record PortalEntry(Fiber declaringFiber, int seq, Element child, Rect area) {}
 
@@ -81,7 +87,7 @@ public final class RenderContext {
     fiber = prev.child(index);
     hookIndex = 0;
     hooks.touched.add(fiber);
-    events.recordBounds(fiber, area);
+    events.recordBounds(fiber, area, currentZ);
     reconcile(fiber, child);
     try {
       child.render(this, area);
@@ -97,7 +103,7 @@ public final class RenderContext {
     fiber = prev.child(key);
     hookIndex = 0;
     hooks.touched.add(fiber);
-    events.recordBounds(fiber, area);
+    events.recordBounds(fiber, area, currentZ);
     reconcile(fiber, child);
     try {
       child.render(this, area);
@@ -235,6 +241,54 @@ public final class RenderContext {
     java.util.concurrent.ScheduledFuture<?> future;
   }
 
+  /// Animation frame hook — the declarative alternative to a hand-rolled render loop. Drives
+  /// `onTick` at up to `hz` frames per second, passing the elapsed milliseconds since this hook's
+  /// previous tick (so animation math is frame-rate independent — advance by `elapsed`, not a
+  /// fixed step).
+  ///
+  /// Mechanics, mirroring [#useTimeout] but self-re-arming:
+  ///   - The hook contributes its `hz` to this render's [#frameMaxHz]. After render, [Renderer]
+  ///     runs a single shared tick source at the highest `hz` any mounted `useFrame` asked for,
+  ///     which [#requestRerender]s at that cadence. While a frame source is live, [ReactApp]
+  ///     shortens its input poll so those re-renders are picked up promptly (~60fps-capable).
+  ///   - `onTick` runs synchronously here, on the render thread, at the next render — exactly like
+  ///     `useTimeout`'s callback. So `state.set(...)` from inside `onTick` is safe.
+  ///   - A tick fires only once this hook's own `1000/hz` ms period has elapsed since its last
+  ///     tick, so a slow (e.g. 10hz) hook coexisting with a fast (60hz) one still ticks at its own
+  ///     rate even though the shared source runs at 60hz.
+  ///   - Auto-cancels on unmount: an unmounted fiber stops contributing to [#frameMaxHz], so the
+  ///     tick source winds down (or stops) automatically; its hook state is swept.
+  ///
+  /// The first render after mount does not tick — it establishes the baseline timestamp; the first
+  /// `onTick` arrives one period later.
+  public void useFrame(int hz, Consumer<Long> onTick) {
+    if (hz <= 0) throw new IllegalArgumentException("useFrame hz must be positive, got " + hz);
+    HookKey key = new HookKey(fiber, hookIndex++);
+    FrameHookState state = (FrameHookState) hooks.values.get(key);
+    long now = System.currentTimeMillis();
+    if (state == null) {
+      state = new FrameHookState();
+      state.lastTickMs = now;
+      hooks.values.put(key, state);
+    }
+
+    // Advertise our rate so Renderer runs the shared tick source fast enough for us.
+    frameMaxHz = Math.max(frameMaxHz, hz);
+
+    long periodMs = Math.max(1L, 1000L / hz);
+    long elapsed = now - state.lastTickMs;
+    if (elapsed >= periodMs) {
+      state.lastTickMs = now;
+      onTick.accept(elapsed);
+    }
+  }
+
+  /// Mutable hook-store entry for [#useFrame]. Tracks the timestamp of this hook's last tick so
+  /// each hook can pace itself independently of the shared tick source's rate.
+  static final class FrameHookState {
+    long lastTickMs;
+  }
+
   /// Shared daemon executor for [#useTimeout]. One thread per process, regardless of how many
   /// hooks are armed. Spawning a thread per timer would not scale; this matches what
   /// [jatatui.components.toast.ToastsProvider] already does for its own timer needs.
@@ -260,7 +314,13 @@ public final class RenderContext {
   /// Recursively drains portals queued by portal children (last-wins z-order). Called by
   /// [ReactApp] after the main render pass.
   void drainPortals() {
+    int generation = currentZ;
     while (!portals.isEmpty()) {
+      // Each generation of portals paints above the previous one, so bounds it records hit-test
+      // above everything painted so far. Portals queued *by* this batch drain in the next
+      // iteration at a still-higher layer (nested overlays stack).
+      generation++;
+      currentZ = generation;
       java.util.List<PortalEntry> batch = new java.util.ArrayList<>(portals);
       portals.clear();
       for (PortalEntry pe : batch) {
@@ -275,6 +335,7 @@ public final class RenderContext {
         }
       }
     }
+    currentZ = 0;
   }
 
   /// Read the value of `context` from the nearest enclosing provider in the Element tree, or
@@ -363,6 +424,63 @@ public final class RenderContext {
 
   public void onScroll(Consumer<MouseEvent> handler) {
     events.boundsOf(fiber).ifPresent(r -> events.addScroll(fiber, r, handler));
+  }
+
+  /// Register a hover handler. Fires on mouse-move (`MOVE`) over `area` — i.e. whenever the
+  /// pointer, not pressing any button, is over this widget. Route it to `useState` to drive a
+  /// hover-highlight. Bubbles like click; the topmost widget under the pointer gets it first.
+  ///
+  /// Hover is delivered per move, not as enter/leave edges: on each move the widget under the
+  /// pointer is notified. Track "currently hovered" yourself (set state on hover, and the next
+  /// move over a different widget updates it).
+  public void onHover(Rect area, Consumer<MouseEvent> handler) {
+    events.addHover(fiber, area, handler);
+  }
+
+  public void onHover(Consumer<MouseEvent> handler) {
+    events.boundsOf(fiber).ifPresent(r -> events.addHover(fiber, r, handler));
+  }
+
+  public void onHover(Rect area, Runnable handler) {
+    events.addHover(fiber, area, e -> handler.run());
+  }
+
+  public void onHover(Runnable handler) {
+    events.boundsOf(fiber).ifPresent(r -> events.addHover(fiber, r, e -> handler.run()));
+  }
+
+  /// Register a drag handler. Fires on `DRAG` (pointer moved with a button held) over `area`. Read
+  /// [MouseEvent#x] / [MouseEvent#y] to track the pointer — this is what scrubs a timeline or
+  /// drags a splitter. Bubbles like click.
+  ///
+  /// Drag is area-scoped like every other mouse handler: it fires for drags whose current point is
+  /// inside `area`. For a scrub/resize interaction that must keep tracking when the pointer strays,
+  /// register the handler on the enclosing panel's area (via the no-arg overload) rather than on a
+  /// narrow handle, so the whole panel receives the drag.
+  public void onDrag(Rect area, Consumer<MouseEvent> handler) {
+    events.addDrag(fiber, area, handler);
+  }
+
+  public void onDrag(Consumer<MouseEvent> handler) {
+    events.boundsOf(fiber).ifPresent(r -> events.addDrag(fiber, r, handler));
+  }
+
+  /// Register a drag-end handler. Fires on `UP` (button released) over `area` — the natural place
+  /// to commit a scrub/resize or clear a "dragging" flag. Bubbles like click.
+  public void onDragEnd(Rect area, Consumer<MouseEvent> handler) {
+    events.addDragEnd(fiber, area, handler);
+  }
+
+  public void onDragEnd(Consumer<MouseEvent> handler) {
+    events.boundsOf(fiber).ifPresent(r -> events.addDragEnd(fiber, r, handler));
+  }
+
+  public void onDragEnd(Rect area, Runnable handler) {
+    events.addDragEnd(fiber, area, e -> handler.run());
+  }
+
+  public void onDragEnd(Runnable handler) {
+    events.boundsOf(fiber).ifPresent(r -> events.addDragEnd(fiber, r, e -> handler.run()));
   }
 
   /// Register a key handler. Fires when this fiber (or one of its descendants) is focused AND the

--- a/jatatui-react/src/java/jatatui/react/Renderer.java
+++ b/jatatui-react/src/java/jatatui/react/Renderer.java
@@ -1,6 +1,10 @@
 package jatatui.react;
 
 import jatatui.core.terminal.Frame;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /// Production-supported render engine for embedding jatatui-react in a host app that owns its own
@@ -50,6 +54,24 @@ public final class Renderer {
   private final FocusManager focus;
   private final AtomicBoolean dirty;
 
+  // ---- Frame tick source (drives useFrame) ----
+
+  /// Shared daemon scheduler for the frame tick source. One thread per process regardless of how
+  /// many Renderers or `useFrame` hooks are live — matches [RenderContext]'s timeout scheduler.
+  private static final ScheduledExecutorService FRAME_SCHEDULER =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "jatatui-react-frames");
+            t.setDaemon(true);
+            return t;
+          });
+
+  /// The rate the tick source is currently running at, or 0 when no `useFrame` is mounted.
+  private int currentFrameHz = 0;
+
+  /// The live periodic task that `requestRerender`s at `currentFrameHz`, or null when stopped.
+  private ScheduledFuture<?> frameFuture;
+
   public Renderer() {
     this.events = new EventRegistry();
     this.hooks = new HookStore();
@@ -73,11 +95,14 @@ public final class Renderer {
     focus.clearFrame();
     java.util.Optional<String> focusedBefore = focus.currentlyFocused();
     RenderContext ctx = new RenderContext(frame, events, hooks, focus, this::requestRerender);
-    events.recordBounds(Fiber.root(), frame.area());
+    events.recordBounds(Fiber.root(), frame.area(), 0);
     root.render(ctx, frame.area());
     ctx.drainPortals();
     hooks.sweep();
     focus.commit();
+    // Reconcile the frame tick source to whatever `useFrame` hooks asked for this render (0 = none
+    // mounted → stop it). Runs on the render thread, so no lock needed on the future/rate.
+    reconcileFrame(ctx.frameMaxHz);
     // Screen-change case: the previously focused id wasn't re-registered this frame so commit
     // chose a new winner (or the previously focused element unmounted). Request a re-render so
     // the new winner is visible — this frame painted as if nothing were focused there.
@@ -136,6 +161,37 @@ public final class Renderer {
     return events;
   }
 
+  // ---- Frame tick source ----
+
+  /// Bring the tick source in line with the rate requested by mounted `useFrame` hooks this frame.
+  /// Idempotent when the rate is unchanged. `hz == 0` stops the source. Called on the render
+  /// thread at the end of every [#render].
+  private void reconcileFrame(int hz) {
+    if (hz == currentFrameHz) return;
+    if (frameFuture != null) {
+      frameFuture.cancel(false);
+      frameFuture = null;
+    }
+    currentFrameHz = hz;
+    if (hz > 0) {
+      long periodMs = Math.max(1L, 1000L / hz);
+      frameFuture =
+          FRAME_SCHEDULER.scheduleAtFixedRate(
+              this::requestRerender, periodMs, periodMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /// True while at least one `useFrame` hook is mounted (the tick source is running). [ReactApp]
+  /// reads this to shorten its input poll so frame re-renders are picked up at animation speed.
+  public boolean frameActive() {
+    return currentFrameHz > 0;
+  }
+
+  /// The rate the frame tick source is running at (frames/sec), or 0 when no `useFrame` is mounted.
+  public int frameHz() {
+    return currentFrameHz;
+  }
+
   // ---- Dirty tracking ----
 
   /// Mark a re-render pending. Threadsafe. Internal callbacks (`useState.set`, dispatchMouse /
@@ -176,6 +232,9 @@ public final class Renderer {
     hooks.cleanups.clear();
     hooks.memoCache.clear();
     hooks.touched.clear();
+    // No hooks remain, so no useFrame is mounted — stop the tick source until the next render
+    // re-establishes it. (The next render reconciles it back on if the fresh tree uses useFrame.)
+    reconcileFrame(0);
     requestRerender();
   }
 


### PR DESCRIPTION
Two additions the react layer needs to drive an animated, mouse-driven app, plus a demo.

## `useFrame(hz, onTick)`

The declarative alternative to a hand-rolled `Renderer` loop. A component asks for a tick rate and
is called back with the elapsed millis **since its own previous tick**, so animation math stays
frame-rate independent.

The tick source lives in `Renderer`, not `ReactApp`: `render()` ends by reconciling one shared
daemon-scheduled task to the highest `hz` any mounted hook asked for (`0` stops it), and that task
`requestRerender`s at that cadence. So it works for any event loop that renders on `takeDirty()` —
`ReactApp` just additionally shortens its poll to ~8ms while `frameActive()`, so those re-renders
are picked up at animation speed.

Per-hook pacing means a 10hz hook coexisting with a 60hz one still ticks at its own rate. Hooks
auto-cancel on unmount: an unmounted fiber stops contributing to `frameMaxHz`, so the source winds
down on its own.

## Mouse beyond click and scroll

`onHover` (MOVE), `onDrag` (DRAG) and `onDragEnd` (UP), each in the same four shapes as `onClick` —
area-scoped or whole-component, taking the event or a bare `Runnable`. `EventRegistry` routes those
kinds and records bounds with a **paint-order z**, bumped per portal generation in `drainPortals`,
so an overlay hit-tests above the content it covers instead of resolving by fiber depth alone.

That is what lets a screen pan a pane by dragging it, or highlight the row under the pointer.

## Notes

- `FrameExample` in the demo launcher exercises the hook.
- Formatting is clean under the new gate from #82; the doc-comment conflicts with that PR were
  resolved keeping this branch's text, reflowed to sit under the wrap limit.
- Locally 7 `ReactAppFocusKeyTest` cases fail with *"Native library
  libnative-arm64-darwin-crossterm.dylib cannot be found on the classpath"* — pre-existing on `main`
  on this machine and unrelated to this change; CI builds the JNI library and runs them.

Used in anger by [dfmt](https://github.com/datoria-dev/dlab)'s formatter TUI: `useFrame` drives a
token-level morph animation, and `onDrag`/`onDragEnd` pan its preview pane.
